### PR TITLE
Adds r-value overloads for monadic operations in rfl::Result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Prerequisites
 *.d
 
+# Temporary files created by IDE or VSCode
+**/.cache
+**/.idea
+
 # Compiled Object files
 *.slo
 *.lo

--- a/include/rfl/Flatten.hpp
+++ b/include/rfl/Flatten.hpp
@@ -15,6 +15,9 @@ struct Flatten {
   /// The underlying type.
   using Type = std::remove_cvref_t<T>;
 
+  /// Default constructor with the underlying object value-initialized
+  Flatten() = default;
+
   Flatten(const Type& _value) : value_(_value) {}
 
   Flatten(Type&& _value) noexcept : value_(std::forward<Type>(_value)) {}
@@ -38,6 +41,21 @@ struct Flatten {
   Flatten(U&& _value) : value_(_value) {}
 
   ~Flatten() = default;
+
+  /// Returns the underlying object.
+  Type& operator*() { return value_; }
+
+  /// Returns the underlying object.
+  const Type& operator*() const { return value_; }
+
+  /// Returns the underlying object.
+  Type* operator->() { return &value_; }
+
+  /// Returns the underlying object.
+  const Type* operator->() const { return &value_; }
+
+  /// Returns the underlying object.
+  Type& get() { return value_; }
 
   /// Returns the underlying object.
   const Type& get() const { return value_; }

--- a/include/rfl/Rename.hpp
+++ b/include/rfl/Rename.hpp
@@ -70,6 +70,18 @@ struct Rename {
   /// Returns the underlying object.
   const Type& operator()() const { return value_; }
 
+  /// Returns the underlying object.
+  Type& operator*() { return value_; }
+
+  /// Returns the underlying object.
+  const Type& operator*() const { return value_; }
+
+  /// Returns the underlying object.
+  Type* operator->() { return &value_; }
+
+  /// Returns the underlying object.
+  const Type* operator->() const { return &value_; }
+
   /// Assigns the underlying object.
   auto& operator=(const Type& _value) {
     value_ = _value;

--- a/include/rfl/Result.hpp
+++ b/include/rfl/Result.hpp
@@ -118,7 +118,7 @@ class Result {
 
     const auto handle_variant =
         [&]<class TOrError>(TOrError&& _t_or_err) -> Result_U {
-      if constexpr (!std::is_same<std::remove_cv_t<TOrError>, Error>()) {
+      if constexpr (!std::is_same<std::remove_cvref_t<TOrError>, Error>()) {
         return _f(std::forward<TOrError>(_t_or_err));
       } else {
         return std::forward<TOrError>(_t_or_err);
@@ -136,7 +136,7 @@ class Result {
 
     const auto handle_variant =
         [&]<class TOrError>(TOrError&& _t_or_err) -> Result_U {
-      if constexpr (!std::is_same<std::remove_cv_t<TOrError>, Error>()) {
+      if constexpr (!std::is_same<std::remove_cvref_t<TOrError>, Error>()) {
         return _f(std::forward<TOrError>(_t_or_err));
       } else {
         return std::forward<TOrError>(_t_or_err);

--- a/include/rfl/Validator.hpp
+++ b/include/rfl/Validator.hpp
@@ -102,6 +102,18 @@ struct Validator {
   /// Exposes the underlying value.
   const T& value() const { return value_; }
 
+  /// Exposes the underlying value, equivalent to value().
+  T& operator*() { return value_; }
+
+  /// Exposes the underlying value, equivalent to value().
+  const T& operator*() const { return value_; }
+
+  /// Exposes the underlying value, equivalent to addressof(value()).
+  T* operator->() { return &value_; }
+
+  /// Exposes the underlying value, equivalent to addressof(value()).
+  const T& operator->() const { return &value_; }
+
   /// Necessary for the serialization to work.
   const T& reflection() const { return value_; }
 


### PR DESCRIPTION
Changes:
1. Adds r-value overloads for monadic operations in `rfl::Result`, i.e. `rfl::Result<T>::and_then(const F&) &&` and  `rfl::Result<T>::and_then(const F&) const &&` etc.
2. Adds `operator->` for `rfl::Result` and `rfl::Validator`