### PR TITLE
Two tiny changes to fix compilation errors on the clang / Dawwin platform.

### DIFF
--- a/include/rfl/Result.hpp
+++ b/include/rfl/Result.hpp
@@ -5,6 +5,7 @@
 #include <ranges>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <variant>

--- a/include/rfl/internal/StringLiteral.hpp
+++ b/include/rfl/internal/StringLiteral.hpp
@@ -28,7 +28,7 @@ struct StringLiteral {
     return std::string_view(std::data(arr_), N - 1);
   }
 
-  std::array<char, N - 1> arr_;
+    std::array<char, N - 1> arr_{};
 };
 
 template <size_t N1, size_t N2>


### PR DESCRIPTION
These are two tiny changes that fix compilation errors on the clang / Darwin platform.

1. Add default initialization to `arr_` in StringLiteral.hpp #48 
2. Add include for `<string>` in Result.hpp
