### PR TITLE
Make library work on clang on windows

### DIFF
--- a/include/rfl/internal/enums/get_enum_names.hpp
+++ b/include/rfl/internal/enums/get_enum_names.hpp
@@ -41,8 +41,12 @@ namespace enums {
 
 template <auto e>
 consteval auto get_enum_name_str_view() {
+#if defined(__clang__) && defined(_MSC_VER)
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
+#else
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 1);
   return split.substr(split.find("e = ") + 4);

--- a/include/rfl/internal/get_field_names.hpp
+++ b/include/rfl/internal/get_field_names.hpp
@@ -43,8 +43,12 @@ constexpr auto wrap(const T& arg) noexcept {
 
 template <class T, auto ptr>
 consteval auto get_field_name_str_view() {
+#if defined(__clang__) && defined(_MSC_VER)
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
+#else
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 2);
   return split.substr(split.find_last_of(".") + 1);

--- a/include/rfl/internal/get_type_name.hpp
+++ b/include/rfl/internal/get_type_name.hpp
@@ -10,8 +10,12 @@ namespace internal {
 
 template <class T>
 consteval auto get_type_name_str_view() {
+#if defined(__clang__) && defined(_MSC_VER)
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
+#else
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 1);
   return split.substr(split.find("T = ") + 4);


### PR DESCRIPTION
This fixes https://github.com/getml/reflect-cpp/issues/56.

As described in that issue, the `function_name()` obtained from `std::source_location` on clang on windows does not include template parameters, which means the tricks used by the library to determine names automatically just don't work. However, `__PRETTY_FUNCTION__` does contain the template parameters and gives the exact string we wanted.

This works whether running clang directly on Windows or whether via `clang-cl`, since both `__clang__` and `_MSC_VER` are defined in either case.

I did a few tests of some basic functionality of the library and everything seemed to work as expected now.