### PR TITLE
feat: add support for parsing std::wstrings

### DIFF
--- a/include/rfl/parsing/Parser.hpp
+++ b/include/rfl/parsing/Parser.hpp
@@ -23,5 +23,6 @@
 #include "Parser_unique_ptr.hpp"
 #include "Parser_variant.hpp"
 #include "Parser_vector_like.hpp"
+#include "Parser_wstring.hpp"
 
 #endif

--- a/include/rfl/parsing/Parser_wstring.hpp
+++ b/include/rfl/parsing/Parser_wstring.hpp
@@ -1,0 +1,74 @@
+#ifndef RFL_PARSING_PARSER_WSTRING_HPP_
+#define RFL_PARSING_PARSER_WSTRING_HPP_
+
+#include <type_traits>
+
+#include "../Result.hpp"
+#include "../always_false.hpp"
+#include "Parent.hpp"
+#include "Parser_base.hpp"
+
+namespace rfl {
+namespace parsing {
+
+template <class R, class W>
+  requires AreReaderAndWriter<R, W, std::wstring>
+struct Parser<R, W, std::wstring> {
+ public:
+  using InputVarType = typename R::InputVarType;
+  using OutputVarType = typename W::OutputVarType;
+
+  using ParentType = Parent<W>;
+
+  static Result<std::wstring> read(const R& _r,
+                                   const InputVarType& _var) noexcept {
+    if (_r.is_empty(_var)) {
+      return std::wstring();
+    }
+
+    auto inStr = Parser<R, W, std::string>::read(_r, _var);
+    if (auto err = inStr.error(); err.has_value()) {
+      return Result<std::wstring>(err.value());
+    }
+
+    std::mbstate_t state = std::mbstate_t();
+    auto val = inStr.value();
+
+    std::wstring outStr(L'\0', val.size());
+
+    // Explicitly set the size so we don't empty it when we truncate
+    outStr.resize(val.size());
+
+    auto* ptr = val.c_str();
+
+    // Add 1 for null terminator
+    auto len = std::mbsrtowcs(outStr.data(), &ptr, val.size(), &state) + 1;
+    outStr.resize(len);  // Truncate the extra bytes
+
+    return Result<std::wstring>(outStr);
+  }
+
+  template <class P>
+  static void write(const W& _w, const std::wstring& _str,
+                    const P& _parent) noexcept {
+    if (_str.empty()) {
+      ParentType::add_value(_w, std::string(), _parent);
+      return;
+    }
+
+    std::mbstate_t state = std::mbstate_t();
+    std::string outStr('\0', _str.size());
+    outStr.resize(_str.size());
+
+    auto* ptr = _str.c_str();
+    auto len = std::wcsrtombs(outStr.data(), &ptr, _str.size(), &state) + 1;
+    outStr.resize(len);
+
+    ParentType::add_value(_w, outStr, _parent);
+  }
+};
+
+}  // namespace parsing
+}  // namespace rfl
+
+#endif

--- a/tests/bson/test_wstring.cpp
+++ b/tests/bson/test_wstring.cpp
@@ -1,0 +1,26 @@
+#include "test_wstring.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+struct Test {
+  std::string theNormalString;
+  std::wstring theWiderString;
+};
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  const Test test = Test{.theNormalString = "The normal string",
+                         .theWiderString = L"The wider string"};
+
+  write_and_read(test);
+}
+}  // namespace test_wstring

--- a/tests/bson/test_wstring.hpp
+++ b/tests/bson/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/bson/tests.cpp
+++ b/tests/bson/tests.cpp
@@ -28,6 +28,7 @@
 #include "test_unique_ptr.hpp"
 #include "test_unique_ptr2.hpp"
 #include "test_variant.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -60,6 +61,7 @@ int main() {
   test_custom_class4::test();
   test_default_values::test();
   test_save_load::test();
+  test_wstring::test();
 
   return 0;
 }

--- a/tests/cbor/test_wstring.cpp
+++ b/tests/cbor/test_wstring.cpp
@@ -1,0 +1,26 @@
+#include "test_wstring.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+struct Test {
+  std::string theNormalString;
+  std::wstring theWiderString;
+};
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  const Test test = Test{.theNormalString = "The normal string",
+                         .theWiderString = L"The wider string"};
+
+  write_and_read(test);
+}
+}  // namespace test_wstring

--- a/tests/cbor/test_wstring.hpp
+++ b/tests/cbor/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/cbor/tests.cpp
+++ b/tests/cbor/tests.cpp
@@ -28,6 +28,7 @@
 #include "test_unique_ptr.hpp"
 #include "test_unique_ptr2.hpp"
 #include "test_variant.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -60,6 +61,7 @@ int main() {
   test_custom_class4::test();
   test_default_values::test();
   test_save_load::test();
+  test_wstring::test();
 
   return 0;
 }

--- a/tests/flexbuffers/test_wstring.cpp
+++ b/tests/flexbuffers/test_wstring.cpp
@@ -1,0 +1,26 @@
+#include "test_wstring.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+struct Test {
+  std::string theNormalString;
+  std::wstring theWiderString;
+};
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  const Test test = Test{.theNormalString = "The normal string",
+                         .theWiderString = L"The wider string"};
+
+  write_and_read(test);
+}
+}  // namespace test_wstring

--- a/tests/flexbuffers/test_wstring.hpp
+++ b/tests/flexbuffers/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/flexbuffers/tests.cpp
+++ b/tests/flexbuffers/tests.cpp
@@ -31,6 +31,7 @@
 #include "test_unordered_multiset.hpp"
 #include "test_unordered_set.hpp"
 #include "test_variant.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -70,6 +71,7 @@ int main() {
   test_all_of::test();
 
   test_save_load::test();
+  test_wstring::test();
 
   return 0;
 }

--- a/tests/json/test_wstring.cpp
+++ b/tests/json/test_wstring.cpp
@@ -1,0 +1,22 @@
+#include "test_wstring.hpp"
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <source_location>
+#include <string>
+
+#include "write_and_read.hpp"
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  std::map<std::string, std::wstring> homer;
+  homer.insert(std::make_pair("firstName", L"Homer"));
+
+  write_and_read(homer, R"({"firstName":"Homer"})");
+}
+}  // namespace test_wstring

--- a/tests/json/test_wstring.hpp
+++ b/tests/json/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/json/tests.cpp
+++ b/tests/json/tests.cpp
@@ -69,6 +69,7 @@
 #include "test_unordered_set.hpp"
 #include "test_variant.hpp"
 #include "test_view.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -149,6 +150,8 @@ int main() {
   test_save_load::test();
 
   test_meta_fields::test();
+
+  test_wstring::test();
 
   return 0;
 }

--- a/tests/xml/test_wstring.cpp
+++ b/tests/xml/test_wstring.cpp
@@ -1,0 +1,26 @@
+#include "test_wstring.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+struct Test {
+  std::string theNormalString;
+  std::wstring theWiderString;
+};
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  const Test test = Test{.theNormalString = "The normal string",
+                         .theWiderString = L"The wider string"};
+
+  write_and_read<"root">(test);
+}
+}  // namespace test_wstring

--- a/tests/xml/test_wstring.hpp
+++ b/tests/xml/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/xml/tests.cpp
+++ b/tests/xml/tests.cpp
@@ -29,6 +29,7 @@
 #include "test_unique_ptr2.hpp"
 #include "test_variant.hpp"
 #include "test_xml_content.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -62,6 +63,7 @@ int main() {
   test_custom_class4::test();
   test_default_values::test();
   test_save_load::test();
+  test_wstring::test();
 
   return 0;
 }

--- a/tests/yaml/test_wstring.cpp
+++ b/tests/yaml/test_wstring.cpp
@@ -1,0 +1,26 @@
+#include "test_wstring.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+struct Test {
+  std::string theNormalString;
+  std::wstring theWiderString;
+};
+
+namespace test_wstring {
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  const Test test = Test{.theNormalString = "The normal string",
+                         .theWiderString = L"The wider string"};
+
+  write_and_read(test);
+}
+}  // namespace test_wstring

--- a/tests/yaml/test_wstring.hpp
+++ b/tests/yaml/test_wstring.hpp
@@ -1,0 +1,3 @@
+namespace test_wstring {
+    void test();
+}

--- a/tests/yaml/tests.cpp
+++ b/tests/yaml/tests.cpp
@@ -29,6 +29,7 @@
 #include "test_unique_ptr.hpp"
 #include "test_unique_ptr2.hpp"
 #include "test_variant.hpp"
+#include "test_wstring.hpp"
 
 int main() {
   test_readme_example::test();
@@ -62,6 +63,7 @@ int main() {
   test_default_values::test();
   test_custom_constructor::test();
   test_save_load::test();
+  test_wstring::test();
 
   return 0;
 }


### PR DESCRIPTION
Adds a conversion to/fro wstring while parsing using wcstombs/mbstowcs. Due to the differences between various implementations and the C++ standard depreciating wstring_convert, this is the best solution I could think of. Let me know if there are potentially better ideas/implementations.

If I have missed anything, do let me know - this is a compicated repo! 😸 