### PR TITLE
fix: handle wstrings being different lengths and constructed correctly

### DIFF
--- a/include/rfl/parsing/Parser_wstring.hpp
+++ b/include/rfl/parsing/Parser_wstring.hpp
@@ -37,7 +37,7 @@ struct Parser<R, W, std::wstring> {
     std::wstring outStr(val.size() * 2, L'\0');
 
     // Explicitly set the size so we don't empty it when we truncate
-    outStr.resize(val.size());
+    outStr.resize(val.size() * 2);
 
     auto* ptr = val.c_str();
 
@@ -57,8 +57,8 @@ struct Parser<R, W, std::wstring> {
     }
 
     std::mbstate_t state = std::mbstate_t();
-    std::string outStr(_str.size(), '\0');
-    outStr.resize(_str.size());
+    std::string outStr(_str.size() + 1, '\0');
+    outStr.resize(_str.size() + 1);
 
     auto* ptr = _str.c_str();
     auto len = std::wcsrtombs(outStr.data(), &ptr, _str.size(), &state) + 1;

--- a/include/rfl/parsing/Parser_wstring.hpp
+++ b/include/rfl/parsing/Parser_wstring.hpp
@@ -34,7 +34,7 @@ struct Parser<R, W, std::wstring> {
     std::mbstate_t state = std::mbstate_t();
     auto val = inStr.value();
 
-    std::wstring outStr(L'\0', val.size());
+    std::wstring outStr(val.size() * 2, L'\0');
 
     // Explicitly set the size so we don't empty it when we truncate
     outStr.resize(val.size());
@@ -57,7 +57,7 @@ struct Parser<R, W, std::wstring> {
     }
 
     std::mbstate_t state = std::mbstate_t();
-    std::string outStr('\0', _str.size());
+    std::string outStr(_str.size(), '\0');
     outStr.resize(_str.size());
 
     auto* ptr = _str.c_str();


### PR DESCRIPTION
Hiya. I made a mistake when doing the original wstring parser. It would crash when trying to construct a wstring for reading due to the parameters being inverted. I tested it on MSVC which worked fine, but when setting it up on Clang it crashed.