### PR TITLE
Add helpers for inspecting enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ This results in the following JSON string:
 {"pos_x":2.0,"pos_y":3.0,"shape":"square","color":"red|blue"}
 ```
 
+You can also directly convert between enumerator values and strings with `rfl::enum_to_string()` and `rfl::string_to_enum()`, or
+obtain list of enumerator name and value pairs with `rfl::get_enumerators<EnumType>()` or `rfl::get_enumerator_array<EnumType>()`.
+
 ## Algebraic data types
 
 reflect-cpp supports Pydantic-style tagged unions, which allow you to form algebraic data types:

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -146,3 +146,39 @@ This will be represented as follows:
 
 This works, because 16 + 256 + 512 + 1024 + 8192 = 10000. Flag enums are *always* represented in terms of 2^N-numbers.
 
+## General-purpose enumeration utilities
+
+reflect-cpp also allows you to directly convert between enumeration values and strings:
+
+```cpp
+enum class Color { red, green, blue };
+
+auto name = rfl::enum_to_string(Color::red);       // "red"
+auto value = rfl::string_to_enum<Color>("red");    // result containing Color::red
+auto value = rfl::string_to_enum<Color>("greem");  // error result
+```
+
+This works with normal and flag enums, and behaves just like serialization of types containing enumerations as described above.
+
+You can also inspect the defined enumerators of an enum type (including at compile-time):
+
+```cpp
+enum class Color { red, green, blue };
+
+// This produces a named tuple where the keys are "red", "green", and "blue", with corresponding
+// values Color::red, Color::green, and Color::blue.
+auto enumerators_named_tuple = rfl::get_enumerators<Color>();
+
+// You can iterate over the enumerators like this:
+enumerators_named_tuple.apply([&](const auto& field) {
+  // field.name() will be "red", "green", "blue"
+  // field.value() will be Color::red, Color::green, Color::blue
+});
+
+// This produces the same data as an std::array containing std::pair<std::string_view, Color>,
+// which can be inspected at compile-time.
+constexpr auto enumerator_array = rfl::get_enumerator_array<Color>();
+```
+
+In case it's more convenient to get the enumerator values as values of the enum's underlying type rather than values of the enum type itself,
+there is also `rfl::get_underlying_enumerators<EnumType>()` and `rfl::get_underlying_enumerator_array<EnumType>()`.

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -148,7 +148,7 @@ This works, because 16 + 256 + 512 + 1024 + 8192 = 10000. Flag enums are *always
 
 ## General-purpose enumeration utilities
 
-reflect-cpp also allows you to directly convert between enumeration values and strings:
+reflect-cpp also allows you to directly convert between enumerator values and strings:
 
 ```cpp
 enum class Color { red, green, blue };

--- a/include/rfl.hpp
+++ b/include/rfl.hpp
@@ -33,6 +33,7 @@
 #include "rfl/define_named_tuple.hpp"
 #include "rfl/define_tagged_union.hpp"
 #include "rfl/define_variant.hpp"
+#include "rfl/enums.hpp"
 #include "rfl/extract_discriminators.hpp"
 #include "rfl/field_type.hpp"
 #include "rfl/fields.hpp"

--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -5,18 +5,40 @@
 
 #include "Result.hpp"
 #include "internal/enums/StringConverter.hpp"
+#include "internal/enums/get_enum_names.hpp"
+#include "internal/enums/is_flag_enum.hpp"
 #include "internal/enums/is_scoped_enum.hpp"
 
 namespace rfl {
 
+// Converts an enum value to a string.
 template <internal::enums::is_scoped_enum EnumType>
 std::string enum_to_string(EnumType _enum) {
   return rfl::internal::enums::StringConverter<EnumType>::enum_to_string(_enum);
 }
 
+// Converts a string to a value of the given enum type.
 template <internal::enums::is_scoped_enum EnumType>
 rfl::Result<EnumType> string_to_enum(const std::string& _str) {
   return rfl::internal::enums::StringConverter<EnumType>::string_to_enum(_str);
+}
+
+// Returns a named tuple mapping names of enumerators of the given enum type to
+// their values.
+template <internal::enums::is_scoped_enum EnumType>
+auto get_enumerators() {
+  constexpr auto names = internal::enums::get_enum_names<
+      EnumType, internal::enums::is_flag_enum<EnumType>>();
+  return internal::enums::names_to_enumerator_named_tuple(names);
+}
+
+// Returns an std::array containing pairs of enumerator names (as
+// std::string_view) and values.
+template <internal::enums::is_scoped_enum EnumType>
+constexpr auto get_enumerator_array() {
+  constexpr auto names = internal::enums::get_enum_names<
+      EnumType, internal::enums::is_flag_enum<EnumType>>();
+  return internal::enums::names_to_enumerator_array(names);
 }
 
 }  // namespace rfl

--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -35,10 +35,10 @@ auto get_enumerators() {
 // Returns a named tuple mapping names of enumerators of the given enum type to
 // their underlying values.
 template <internal::enums::is_scoped_enum EnumType>
-auto get_enumerators_underlying() {
+auto get_underlying_enumerators() {
   constexpr auto names = internal::enums::get_enum_names<
       EnumType, internal::enums::is_flag_enum<EnumType>>();
-  return internal::enums::names_to_enumerator_named_tuple_underlying(names);
+  return internal::enums::names_to_underlying_enumerator_named_tuple(names);
 }
 
 // Returns an std::array containing pairs of enumerator names (as
@@ -53,10 +53,10 @@ constexpr auto get_enumerator_array() {
 // Returns an std::array containing pairs of enumerator names (as
 // std::string_view) and underlying values.
 template <internal::enums::is_scoped_enum EnumType>
-constexpr auto get_enumerator_array_underlying() {
+constexpr auto get_underlying_enumerator_array() {
   constexpr auto names = internal::enums::get_enum_names<
       EnumType, internal::enums::is_flag_enum<EnumType>>();
-  return internal::enums::names_to_enumerator_array_underlying(names);
+  return internal::enums::names_to_underlying_enumerator_array(names);
 }
 
 }  // namespace rfl

--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -1,0 +1,24 @@
+#ifndef RFL_ENUMS_HPP_
+#define RFL_ENUMS_HPP_
+
+#include <string>
+
+#include "Result.hpp"
+#include "internal/enums/StringConverter.hpp"
+#include "internal/enums/is_scoped_enum.hpp"
+
+namespace rfl {
+
+template <internal::enums::is_scoped_enum EnumType>
+std::string enum_to_string(EnumType _enum) {
+  return rfl::internal::enums::StringConverter<EnumType>::enum_to_string(_enum);
+}
+
+template <internal::enums::is_scoped_enum EnumType>
+rfl::Result<EnumType> string_to_enum(const std::string& _str) {
+  return rfl::internal::enums::StringConverter<EnumType>::string_to_enum(_str);
+}
+
+}  // namespace rfl
+
+#endif  // RFL_ENUMS_HPP_

--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -32,6 +32,15 @@ auto get_enumerators() {
   return internal::enums::names_to_enumerator_named_tuple(names);
 }
 
+// Returns a named tuple mapping names of enumerators of the given enum type to
+// their underlying values.
+template <internal::enums::is_scoped_enum EnumType>
+auto get_enumerators_underlying() {
+  constexpr auto names = internal::enums::get_enum_names<
+      EnumType, internal::enums::is_flag_enum<EnumType>>();
+  return internal::enums::names_to_enumerator_named_tuple_underlying(names);
+}
+
 // Returns an std::array containing pairs of enumerator names (as
 // std::string_view) and values.
 template <internal::enums::is_scoped_enum EnumType>
@@ -39,6 +48,15 @@ constexpr auto get_enumerator_array() {
   constexpr auto names = internal::enums::get_enum_names<
       EnumType, internal::enums::is_flag_enum<EnumType>>();
   return internal::enums::names_to_enumerator_array(names);
+}
+
+// Returns an std::array containing pairs of enumerator names (as
+// std::string_view) and underlying values.
+template <internal::enums::is_scoped_enum EnumType>
+constexpr auto get_enumerator_array_underlying() {
+  constexpr auto names = internal::enums::get_enum_names<
+      EnumType, internal::enums::is_flag_enum<EnumType>>();
+  return internal::enums::names_to_enumerator_array_underlying(names);
 }
 
 }  // namespace rfl

--- a/include/rfl/internal/enums/Names.hpp
+++ b/include/rfl/internal/enums/Names.hpp
@@ -46,10 +46,27 @@ auto names_to_enumerator_named_tuple(
 }
 
 template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
+auto names_to_enumerator_named_tuple_underlying(
+    Names<EnumType, Literal<_names...>, N, _enums...>) {
+  return make_named_tuple(Field<_names, std::underlying_type_t<EnumType>>{
+      static_cast<std::underlying_type_t<EnumType>>(_enums)}...);
+}
+
+template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
 constexpr std::array<std::pair<std::string_view, EnumType>, N>
 names_to_enumerator_array(Names<EnumType, Literal<_names...>, N, _enums...>) {
   return {
       std::make_pair(LiteralHelper<_names>::field_.string_view(), _enums)...};
+}
+
+template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
+constexpr std::array<
+    std::pair<std::string_view, std::underlying_type_t<EnumType>>, N>
+names_to_enumerator_array_underlying(
+    Names<EnumType, Literal<_names...>, N, _enums...>) {
+  return {
+      std::make_pair(LiteralHelper<_names>::field_.string_view(),
+                     static_cast<std::underlying_type_t<EnumType>>(_enums))...};
 }
 
 }  // namespace enums

--- a/include/rfl/internal/enums/Names.hpp
+++ b/include/rfl/internal/enums/Names.hpp
@@ -46,7 +46,7 @@ auto names_to_enumerator_named_tuple(
 }
 
 template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
-auto names_to_enumerator_named_tuple_underlying(
+auto names_to_underlying_enumerator_named_tuple(
     Names<EnumType, Literal<_names...>, N, _enums...>) {
   return make_named_tuple(Field<_names, std::underlying_type_t<EnumType>>{
       static_cast<std::underlying_type_t<EnumType>>(_enums)}...);
@@ -62,7 +62,7 @@ names_to_enumerator_array(Names<EnumType, Literal<_names...>, N, _enums...>) {
 template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
 constexpr std::array<
     std::pair<std::string_view, std::underlying_type_t<EnumType>>, N>
-names_to_enumerator_array_underlying(
+names_to_underlying_enumerator_array(
     Names<EnumType, Literal<_names...>, N, _enums...>) {
   return {
       std::make_pair(LiteralHelper<_names>::field_.string_view(),

--- a/include/rfl/internal/enums/Names.hpp
+++ b/include/rfl/internal/enums/Names.hpp
@@ -6,9 +6,12 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "../../Literal.hpp"
 #include "../../define_literal.hpp"
+#include "../../make_named_tuple.hpp"
+#include "../StringLiteral.hpp"
 
 namespace rfl {
 namespace internal {
@@ -35,6 +38,19 @@ struct Names {
       Names<EnumType, define_literal_t<LiteralType, NewLiteral>, N + 1,
             _enums..., _new_enum>>;
 };
+
+template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
+auto names_to_enumerator_named_tuple(
+    Names<EnumType, Literal<_names...>, N, _enums...>) {
+  return make_named_tuple(Field<_names, EnumType>{_enums}...);
+}
+
+template <class EnumType, size_t N, StringLiteral... _names, auto... _enums>
+constexpr std::array<std::pair<std::string_view, EnumType>, N>
+names_to_enumerator_array(Names<EnumType, Literal<_names...>, N, _enums...>) {
+  return {
+      std::make_pair(LiteralHelper<_names>::field_.string_view(), _enums)...};
+}
 
 }  // namespace enums
 }  // namespace internal

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -50,6 +50,13 @@ void test() {
   });
   write_and_read(mutable_circle, R"({"radius":2.0,"color":"green"})");
 
+  rfl::get_enumerators_underlying<Color>().apply([&](auto field) {
+    if constexpr (decltype(field)::name() == "blue") {
+      mutable_circle.color = static_cast<Color>(field.value());
+    }
+  });
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"blue"})");
+
   constexpr auto enumerator_array = rfl::get_enumerator_array<Color>();
   static_assert(enumerator_array[0].first == "red");
   static_assert(enumerator_array[1].first == "green");
@@ -59,6 +66,16 @@ void test() {
   static_assert(enumerator_array[1].second == Color::green);
   static_assert(enumerator_array[2].second == Color::blue);
   static_assert(enumerator_array[3].second == Color::yellow);
+
+  constexpr auto enumerator_array_underlying = rfl::get_enumerator_array_underlying<Color>();
+  static_assert(enumerator_array_underlying[0].first == "red");
+  static_assert(enumerator_array_underlying[1].first == "green");
+  static_assert(enumerator_array_underlying[2].first == "blue");
+  static_assert(enumerator_array_underlying[3].first == "yellow");
+  static_assert(enumerator_array_underlying[0].second == 0);
+  static_assert(enumerator_array_underlying[1].second == 1);
+  static_assert(enumerator_array_underlying[2].second == 2);
+  static_assert(enumerator_array_underlying[3].second == 3);
 }
 
 }  // namespace test_enum

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -67,7 +67,8 @@ void test() {
   static_assert(enumerator_array[2].second == Color::blue);
   static_assert(enumerator_array[3].second == Color::yellow);
 
-  constexpr auto enumerator_array_underlying = rfl::get_underlying_enumerator_array<Color>();
+  constexpr auto enumerator_array_underlying =
+      rfl::get_underlying_enumerator_array<Color>();
   static_assert(enumerator_array_underlying[0].first == "red");
   static_assert(enumerator_array_underlying[1].first == "green");
   static_assert(enumerator_array_underlying[2].first == "blue");

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -50,7 +50,7 @@ void test() {
   });
   write_and_read(mutable_circle, R"({"radius":2.0,"color":"green"})");
 
-  rfl::get_enumerators_underlying<Color>().apply([&](auto field) {
+  rfl::get_underlying_enumerators<Color>().apply([&](auto field) {
     if constexpr (decltype(field)::name() == "blue") {
       mutable_circle.color = static_cast<Color>(field.value());
     }
@@ -67,7 +67,7 @@ void test() {
   static_assert(enumerator_array[2].second == Color::blue);
   static_assert(enumerator_array[3].second == Color::yellow);
 
-  constexpr auto enumerator_array_underlying = rfl::get_enumerator_array_underlying<Color>();
+  constexpr auto enumerator_array_underlying = rfl::get_underlying_enumerator_array<Color>();
   static_assert(enumerator_array_underlying[0].first == "red");
   static_assert(enumerator_array_underlying[1].first == "green");
   static_assert(enumerator_array_underlying[2].first == "blue");

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -25,6 +25,23 @@ void test() {
   const auto circle = Circle{.radius = 2.0, .color = Color::green};
 
   write_and_read(circle, R"({"radius":2.0,"color":"green"})");
+
+  auto mutable_circle = Circle{.radius = 2.0, .color = Color::green};
+  if (auto color = rfl::string_to_enum<Color>("red"); color) {
+    mutable_circle.color = *color;
+  }
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"red"})");
+
+  if (auto color = rfl::string_to_enum<Color>("bart"); color) {
+    mutable_circle.color = *color;
+  }
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"red"})");
+
+  if (auto color = rfl::string_to_enum<Color>(rfl::enum_to_string(Color::blue));
+      color) {
+    mutable_circle.color = *color;
+  }
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"blue"})");
 }
 
 }  // namespace test_enum

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -26,7 +26,7 @@ void test() {
 
   write_and_read(circle, R"({"radius":2.0,"color":"green"})");
 
-  auto mutable_circle = Circle{.radius = 2.0, .color = Color::green};
+  auto mutable_circle = circle;
   if (auto color = rfl::string_to_enum<Color>("red"); color) {
     mutable_circle.color = *color;
   }
@@ -42,6 +42,23 @@ void test() {
     mutable_circle.color = *color;
   }
   write_and_read(mutable_circle, R"({"radius":2.0,"color":"blue"})");
+
+  rfl::get_enumerators<Color>().apply([&](auto field) {
+    if constexpr (decltype(field)::name() == "green") {
+      mutable_circle.color = field.value();
+    }
+  });
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"green"})");
+
+  constexpr auto enumerator_array = rfl::get_enumerator_array<Color>();
+  static_assert(enumerator_array[0].first == "red");
+  static_assert(enumerator_array[1].first == "green");
+  static_assert(enumerator_array[2].first == "blue");
+  static_assert(enumerator_array[3].first == "yellow");
+  static_assert(enumerator_array[0].second == Color::red);
+  static_assert(enumerator_array[1].second == Color::green);
+  static_assert(enumerator_array[2].second == Color::blue);
+  static_assert(enumerator_array[3].second == Color::yellow);
 }
 
 }  // namespace test_enum

--- a/tests/json/test_enum.cpp
+++ b/tests/json/test_enum.cpp
@@ -50,8 +50,8 @@ void test() {
   });
   write_and_read(mutable_circle, R"({"radius":2.0,"color":"green"})");
 
-  rfl::get_underlying_enumerators<Color>().apply([&](auto field) {
-    if constexpr (decltype(field)::name() == "blue") {
+  rfl::get_underlying_enumerators<Color>().apply([&](const auto& field) {
+    if (field.name() == "blue") {
       mutable_circle.color = static_cast<Color>(field.value());
     }
   });

--- a/tests/json/test_flag_enum.cpp
+++ b/tests/json/test_flag_enum.cpp
@@ -35,6 +35,14 @@ void test() {
       Circle{.radius = 2.0, .color = Color::blue | Color::orange};
 
   write_and_read(circle, R"({"radius":2.0,"color":"red|blue|yellow"})");
+
+  auto mutable_circle = circle;
+  rfl::get_enumerators<Color>().apply([&](auto field) {
+    if constexpr (decltype(field)::name() == "green") {
+      mutable_circle.color = field.value();
+    }
+  });
+  write_and_read(mutable_circle, R"({"radius":2.0,"color":"green"})");
 }
 
 }  // namespace test_flag_enum


### PR DESCRIPTION
In the same spirit as https://github.com/getml/reflect-cpp/pull/59, I'd like reflect-cpp to expose general-purpose enum reflection utilities (since it already knows how to do this internally), without having to depend on `rfl::internal` or implement things myself.

This PR adds four functions in a new `rfl/enums.hpp` file:

* `rfl::enum_to_string(enum)` and `rfl::string_to_enum<EnumType>(string)` are simple wrappers around the existing internal functions.
* `rfl::get_enumerators<EnumType>()` gives back a named tuple of enumerator names/values, while `rfl::get_enumerator_array<EnumType>` gives back the same data as an `std::array` of pairs (the main advantage of this one being that it can be `constexpr`).

Example:

```
enum class Color { red, green, blue };
get_enumerators<EnumType>() == NamedTuple{make_field<"red">(Color::red), make_field<"blue">(Color::blue), make_field<"green">(Color::green)}
get_enumerator_array<EnumType>() == std::array{std::make_pair("red", Color::red), std::make_pair("green", Color::green), std::make_pair("blue", Color::blue)}
```

The tests pass along with some new ones. If you like these changes I'll add some documentation.