### PR TITLE
undo change of parameter type in `NamedTuple::apply`

### DIFF
--- a/include/rfl/NamedTuple.hpp
+++ b/include/rfl/NamedTuple.hpp
@@ -602,7 +602,7 @@ class NamedTuple<> {
 
   /// Does nothing at all.
   template <typename F>
-  void apply(const F& _f) const {}
+  void apply(F&& _f) const {}
 
   /// Returns an empty tuple.
   auto fields() const { return std::tuple(); }

--- a/include/rfl/NamedTuple.hpp
+++ b/include/rfl/NamedTuple.hpp
@@ -199,7 +199,7 @@ class NamedTuple {
 
   /// Invokes a callable object once for each field in order.
   template <typename F>
-  void apply(const F& _f) {
+  void apply(F&& _f) {
     const auto apply_to_field =
         [&_f]<typename... AFields>(AFields&&... fields) {
           ((_f(std::forward<AFields>(fields))), ...);
@@ -209,7 +209,7 @@ class NamedTuple {
 
   /// Invokes a callable object once for each field in order.
   template <typename F>
-  void apply(const F& _f) const {
+  void apply(F&& _f) const {
     const auto apply_to_field = [&_f](const auto&... fields) {
       ((_f(fields)), ...);
     };

--- a/tests/json/test_apply.cpp
+++ b/tests/json/test_apply.cpp
@@ -38,7 +38,7 @@ void test() {
     }
   });
 
-  rfl::to_view(lisa).apply([](auto field) {
+  rfl::to_view(lisa).apply([](auto field) mutable {
     if constexpr (decltype(field)::name() == "first_name") {
       *field.value() = "Bart";
     }


### PR DESCRIPTION
58f1e41c830d2e598415e480939e38df3a76f785 changed the parameter type of the named tuple `apply` method from `F&&` to `const F&`, but this prevents it from being used with non-const objects. There is certainly no reason to disallow this (my fault for not adding a test).