### PR TITLE
Use BUILD_SHARED_LIBS as default value for REFLECTCPP_BUILD_SHARED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-option(REFLECTCPP_BUILD_SHARED "Build shared library" OFF)
+option(REFLECTCPP_BUILD_SHARED "Build shared library" ${BUILD_SHARED_LIBS})
 option(REFLECTCPP_BSON "Enable BSON support" OFF)
 option(REFLECTCPP_CBOR "Enable CBOR support" OFF)
 option(REFLECTCPP_FLEXBUFFERS "Enable flexbuffers support" OFF)


### PR DESCRIPTION
`BUILD_SHARED_LIBS` is the standard cmake variable to indicate if output should be shared libraries, so this should be used to streamline standalone builds.  To not break existing integrations and to make inclusion (eg as submodule) easier this patch leaves `REFLECTCPP_BUILD_SHARED` in place but default-initializes it with the value of `BUILD_SHARED_LIBS`.