### PR TITLE
reflectcpp-config.cmake.in: Fix typo in check_required_components

### DIFF
--- a/reflectcpp-config.cmake.in
+++ b/reflectcpp-config.cmake.in
@@ -34,5 +34,4 @@ if (REFLECTCPP_YAML)
   find_dependency(yaml-cpp)
 endif ()
 
-check_required_components(reflect-cpp)
-
+check_required_components(reflectcpp)


### PR DESCRIPTION
This fixes a typo in the call to check_required_components.
Without this fix it is possible for a consumer to require a component that does not exist without getting an error from cmake.
Eg
```
find_package(reflectcpp REQUIRED COMPONENTS does-not-exist)
```
would succeed, but should result in an error.