### PR TITLE
Fix names of inherited members being prefixed with the base-class's n…

### DIFF
--- a/include/rfl/internal/get_field_names.hpp
+++ b/include/rfl/internal/get_field_names.hpp
@@ -52,7 +52,10 @@ consteval auto get_field_name_str_view() {
 #endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 2);
-  return split.substr(split.find_last_of(".") + 1);
+  const auto possibly_prefixed = split.substr(split.find_last_of(".") + 1);
+  const auto separator_index = possibly_prefixed.find_last_of(":");
+  if (separator_index == std::string_view::npos) return possibly_prefixed;
+  return possibly_prefixed.substr(separator_index + 1);
 #elif defined(__GNUC__)
   const auto split = func_name.substr(0, func_name.size() - 2);
   return split.substr(split.find_last_of(":") + 1);

--- a/include/rfl/internal/get_field_names.hpp
+++ b/include/rfl/internal/get_field_names.hpp
@@ -52,10 +52,7 @@ consteval auto get_field_name_str_view() {
 #endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 2);
-  const auto possibly_prefixed = split.substr(split.find_last_of(".") + 1);
-  const auto separator_index = possibly_prefixed.find_last_of(":");
-  if (separator_index == std::string_view::npos) return possibly_prefixed;
-  return possibly_prefixed.substr(separator_index + 1);
+  return split.substr(split.find_last_of(":.") + 1);  
 #elif defined(__GNUC__)
   const auto split = func_name.substr(0, func_name.size() - 2);
   return split.substr(split.find_last_of(":") + 1);

--- a/tests/json/CMakeLists.txt
+++ b/tests/json/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(reflect-cpp-json-tests)
 
-file(GLOB_RECURSE SOURCES "*.cpp")
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "*.cpp")
 
 add_executable(reflect-cpp-json-tests ${SOURCES})
 

--- a/tests/json/test_inheritance.cpp
+++ b/tests/json/test_inheritance.cpp
@@ -1,0 +1,26 @@
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <source_location>
+
+namespace test_inheritance {
+
+void test() {
+  std::cout << std::source_location::current().function_name() << std::endl;
+
+  struct S {
+    int x;
+  };
+
+  struct T : S {};
+
+  const auto name = get<0>(rfl::fields<T>()).name();
+  if (name == "x") {
+    std::cout << "OK" << std::endl;
+  } else {
+    std::cout << "FAIL\n"
+              << "Expected member name 'x', got '" << name << "'" << std::endl;
+  }
+}
+
+}  // namespace test_inheritance

--- a/tests/json/test_inheritance.hpp
+++ b/tests/json/test_inheritance.hpp
@@ -1,0 +1,3 @@
+namespace test_inheritance{
+void test();
+}

--- a/tests/json/tests.cpp
+++ b/tests/json/tests.cpp
@@ -86,6 +86,7 @@
 #include "test_variant.hpp"
 #include "test_view.hpp"
 #include "test_wstring.hpp"
+#include "test_inheritance.hpp"
 
 int main() {
   test_readme_example::test();
@@ -186,6 +187,8 @@ int main() {
 
   test_wstring::test();
   test_json_schema::test();
+
+  test_inheritance::test();
 
   return 0;
 }


### PR DESCRIPTION
This fixes https://github.com/getml/reflect-cpp/issues/13#issuecomment-2041485649