### PR TITLE
[fix] 64bit int support for json

### DIFF
--- a/include/rfl/json/Reader.hpp
+++ b/include/rfl/json/Reader.hpp
@@ -79,11 +79,16 @@ struct Reader {
         return rfl::Error("Could not cast to double.");
       }
       return static_cast<T>(yyjson_get_num(_var.val_));
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      if (!yyjson_is_int(_var.val_)) {
+        return rfl::Error("Could not cast to int.");
+      }
+      return static_cast<T>(yyjson_get_uint(_var.val_));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
       if (!yyjson_is_int(_var.val_)) {
         return rfl::Error("Could not cast to int.");
       }
-      return static_cast<T>(yyjson_get_int(_var.val_));
+      return static_cast<T>(yyjson_get_sint(_var.val_));
     } else {
       static_assert(rfl::always_false_v<T>, "Unsupported type.");
     }

--- a/include/rfl/json/Writer.hpp
+++ b/include/rfl/json/Writer.hpp
@@ -150,8 +150,10 @@ class Writer {
       return OutputVarType(yyjson_mut_bool(doc_, _var));
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       return OutputVarType(yyjson_mut_real(doc_, static_cast<double>(_var)));
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      return OutputVarType(yyjson_mut_uint(doc_, static_cast<uint64_t>(_var)));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      return OutputVarType(yyjson_mut_int(doc_, static_cast<int>(_var)));
+      return OutputVarType(yyjson_mut_int(doc_, static_cast<int64_t>(_var)));
     } else {
       static_assert(rfl::always_false_v<T>, "Unsupported type.");
     }

--- a/tests/json/test_integers.cpp
+++ b/tests/json/test_integers.cpp
@@ -1,0 +1,27 @@
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <source_location>
+#include <string>
+
+#include "write_and_read.hpp"
+
+namespace test_integers {
+
+TEST(json, test_integers) {
+
+  struct Integers {
+      int i32;
+      unsigned int u32;
+      long long i64;
+      unsigned long long u64;
+  };
+
+  write_and_read(Integers{.i32 = INT32_MAX, .u32 = UINT32_MAX, .i64 = INT64_MAX, .u64 = UINT64_MAX}, R"({"i32":2147483647,"u32":4294967295,"i64":9223372036854775807,"u64":18446744073709551615})");
+  write_and_read(Integers{.i32 = INT32_MIN, .u32 = 0, .i64 = INT64_MIN, .u64 = 0}, R"({"i32":-2147483648,"u32":0,"i64":-9223372036854775808,"u64":0})");
+}
+
+}  // namespace test_integers

--- a/tests/json/test_integers.cpp
+++ b/tests/json/test_integers.cpp
@@ -1,11 +1,6 @@
 #include <cstdint>
-#include <iostream>
-#include <map>
-#include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
-#include <string>
 
 #include "write_and_read.hpp"
 


### PR DESCRIPTION
Json reader and writer now handle 64bit ints correctly, no longer casts them to a i32. Added test checking full int range 