### PR TITLE
Update wstring parser to remove needless null terminators

### DIFF
--- a/include/rfl/parsing/Parser_wstring.hpp
+++ b/include/rfl/parsing/Parser_wstring.hpp
@@ -44,7 +44,7 @@ struct Parser<R, W, std::wstring, ProcessorsType> {
     auto* ptr = val.c_str();
 
     // Add 1 for null terminator
-    auto len = std::mbsrtowcs(outStr.data(), &ptr, val.size(), &state) + 1;
+    auto len = std::mbsrtowcs(outStr.data(), &ptr, val.size(), &state);
     outStr.resize(len);  // Truncate the extra bytes
 
     return Result<std::wstring>(outStr);
@@ -59,11 +59,11 @@ struct Parser<R, W, std::wstring, ProcessorsType> {
     }
 
     std::mbstate_t state = std::mbstate_t();
-    std::string outStr(_str.size() + 1, '\0');
-    outStr.resize(_str.size() + 1);
+    std::string outStr(_str.size(), '\0');
+    outStr.resize(_str.size());
 
     auto* ptr = _str.c_str();
-    auto len = std::wcsrtombs(outStr.data(), &ptr, _str.size(), &state) + 1;
+    auto len = std::wcsrtombs(outStr.data(), &ptr, _str.size(), &state);
     outStr.resize(len);
 
     ParentType::add_value(_w, outStr, _parent);


### PR DESCRIPTION
Hey again. Sorry to edit the same code again. I made a false assumption with the original code requring explicit null terminators. We have found out that some of our code was breaking due to the extra null terminator being present within the strings. I have removed them as needed.

In hindsight I should have been more thorough with my testing.