### PR TITLE
Feature/compatibilities gcc14 clang14 vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,15 @@ option(REFLECTCPP_BUILD_TESTS "Build tests" OFF)
 option(REFLECTCPP_USE_BUNDLED_DEPENDENCIES "Use the bundled dependencies" ON)
 
 set(REFLECTCPP_USE_VCPKG_DEFAULT OFF)
+if(REFLECTCPP_BUILD_BENCHMARKS)
+    set(REFLECTCPP_BSON ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_CBOR ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_FLEXBUFFERS ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_MSGPACK ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_XML ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_TOML ON CACHE BOOL "" FORCE)
+    set(REFLECTCPP_YAML ON CACHE BOOL "" FORCE)
+endif()
 if (REFLECTCPP_BUILD_TESTS OR REFLECTCPP_BUILD_BENCHMARKS OR REFLECTCPP_BSON OR REFLECTCPP_CBOR OR REFLECTCPP_FLEXBUFFERS OR REFLECTCPP_MSGPACK OR REFLECTCPP_XML OR REFLECTCPP_TOML OR REFLECTCPP_YAML)
     # enable vcpkg per default if require features other than JSON
     set(REFLECTCPP_USE_VCPKG_DEFAULT ON)
@@ -27,44 +36,52 @@ if (REFLECTCPP_USE_VCPKG)
     set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake CACHE STRING "Vcpkg toolchain file")
 endif ()
 
-project(reflectcpp)
+project(reflectcpp LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 
 if(REFLECTCPP_USE_BUNDLED_DEPENDENCIES)
     if (REFLECTCPP_BUILD_SHARED)
-        add_library(reflectcpp SHARED src/yyjson.c)
-    else()
-        add_library(reflectcpp STATIC src/yyjson.c)
-    endif()
-    set_source_files_properties(src/yyjson.c PROPERTIES LANGUAGE CXX)
-else()
-    if (REFLECTCPP_BUILD_SHARED)
         add_library(reflectcpp SHARED)
     else()
         add_library(reflectcpp STATIC)
     endif()
+
+    target_sources(reflectcpp PRIVATE src/yyjson.c)
+    set_source_files_properties(src/yyjson.c PROPERTIES LANGUAGE CXX)
+
+    target_compile_features(reflectcpp PUBLIC cxx_std_20)
+    target_compile_options(reflectcpp PRIVATE $<$<CONFIG:Debug>:-Wall -Wextra>)
+
+    target_include_directories(
+        reflectcpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/rfl/thirdparty>)
+else()
+    add_library(reflectcpp INTERFACE)
+
+    target_include_directories(
+        reflectcpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include> )
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DREFLECTCPP_NO_BUNDLED_DEPENDENCIES")
+    target_compile_features(reflectcpp INTERFACE cxx_std_20)
+
+    find_package(ctre CONFIG REQUIRED)
+    find_package(yyjson CONFIG REQUIRED)
+    target_link_libraries(reflectcpp INTERFACE ctre::ctre yyjson::yyjson)
 endif()
 
 set_target_properties(reflectcpp PROPERTIES LINKER_LANGUAGE CXX)
-target_compile_features(reflectcpp PUBLIC cxx_std_20)
 
-if(REFLECTCPP_USE_BUNDLED_DEPENDENCIES)
-    target_include_directories(reflectcpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/rfl/thirdparty>)
-else()
-    target_include_directories(reflectcpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include> )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DREFLECTCPP_NO_BUNDLED_DEPENDENCIES")
-    find_package(ctre CONFIG REQUIRED)
-    find_package(yyjson CONFIG REQUIRED)
-    target_link_libraries(reflectcpp INTERFACE yyjson::yyjson)
-endif()
-
-if (REFLECTCPP_BSON OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_BSON)
     find_package(bson-1.0 CONFIG REQUIRED)
     target_link_libraries(reflectcpp PRIVATE $<IF:$<TARGET_EXISTS:mongo::bson_static>,mongo::bson_static,mongo::bson_shared>)
 endif ()
 
-if (REFLECTCPP_CBOR OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_CBOR)
     if (MSVC)
         target_link_libraries(reflectcpp PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/tinycbor${CMAKE_STATIC_LIBRARY_SUFFIX}")
     else ()
@@ -72,12 +89,12 @@ if (REFLECTCPP_CBOR OR REFLECTCPP_BUILD_BENCHMARKS)
     endif ()
 endif ()
 
-if (REFLECTCPP_FLEXBUFFERS OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_FLEXBUFFERS)
     find_package(flatbuffers CONFIG REQUIRED)
     target_link_libraries(reflectcpp INTERFACE flatbuffers::flatbuffers)
 endif ()
 
-if (REFLECTCPP_MSGPACK OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_MSGPACK)
     find_package(msgpack-c CONFIG REQUIRED)
     if (MSVC)
         target_link_libraries(reflectcpp PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/msgpack-c${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -86,7 +103,7 @@ if (REFLECTCPP_MSGPACK OR REFLECTCPP_BUILD_BENCHMARKS)
     endif ()
 endif ()
 
-if (REFLECTCPP_TOML OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_TOML)
     if (MSVC)
         target_link_libraries(reflectcpp PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/tomlplusplus${CMAKE_STATIC_LIBRARY_SUFFIX}")
     else ()
@@ -94,17 +111,15 @@ if (REFLECTCPP_TOML OR REFLECTCPP_BUILD_BENCHMARKS)
     endif ()
 endif()
 
-if (REFLECTCPP_XML OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_XML)
     find_package(pugixml CONFIG REQUIRED)
     target_link_libraries(reflectcpp INTERFACE pugixml::pugixml)
 endif ()
 
-if (REFLECTCPP_YAML OR REFLECTCPP_BUILD_BENCHMARKS)
+if (REFLECTCPP_YAML)
     find_package(yaml-cpp CONFIG REQUIRED)
     target_link_libraries(reflectcpp INTERFACE yaml-cpp::yaml-cpp)
 endif ()
-
-target_compile_options(reflectcpp PRIVATE -Wall)
 
 if (REFLECTCPP_BUILD_TESTS)
     if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(REFLECTCPP_USE_BUNDLED_DEPENDENCIES)
     else()
         add_library(reflectcpp STATIC src/yyjson.c)
     endif()
+    set_source_files_properties(src/yyjson.c PROPERTIES LANGUAGE CXX)
 else()
     if (REFLECTCPP_BUILD_SHARED)
         add_library(reflectcpp SHARED)
@@ -60,7 +61,7 @@ endif()
 
 if (REFLECTCPP_BSON OR REFLECTCPP_BUILD_BENCHMARKS)
     find_package(bson-1.0 CONFIG REQUIRED)
-    target_link_libraries(reflectcpp PRIVATE $<IF:$<TARGET_EXISTS:mongo::bson_static>,mongo::bson_static,mongo::bson_shared>) 
+    target_link_libraries(reflectcpp PRIVATE $<IF:$<TARGET_EXISTS:mongo::bson_static>,mongo::bson_static,mongo::bson_shared>)
 endif ()
 
 if (REFLECTCPP_CBOR OR REFLECTCPP_BUILD_BENCHMARKS)
@@ -126,7 +127,7 @@ include(CMakePackageConfigHelpers)
 
 configure_package_config_file(reflectcpp-config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp  
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp
   )
 
 install(
@@ -138,17 +139,17 @@ file(GLOB_RECURSE RFL_HEADERS RELATIVE ${CMAKE_CURRENT_LIST_DIR} "${CMAKE_CURREN
 
 target_sources(reflectcpp
     PUBLIC
-    FILE_SET reflectcpp_headers    
+    FILE_SET reflectcpp_headers
     TYPE HEADERS
     BASE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     FILES ${RFL_HEADERS})
-   
+
 install(
     TARGETS reflectcpp
     EXPORT reflectcpp-exports
     FILE_SET reflectcpp_headers DESTINATION ${INCLUDE_INSTALL_DIR}
     )
-    
+
 install(
     EXPORT reflectcpp-exports
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp

--- a/include/rfl/Literal.hpp
+++ b/include/rfl/Literal.hpp
@@ -1,10 +1,10 @@
 #ifndef RFL_LITERAL_HPP_
 #define RFL_LITERAL_HPP_
 
+#include <compare>
 #include <cstdint>
 #include <functional>
 #include <limits>
-#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -12,7 +12,6 @@
 
 #include "Result.hpp"
 #include "internal/StringLiteral.hpp"
-#include "internal/VisitTree.hpp"
 #include "internal/no_duplicate_field_names.hpp"
 
 namespace rfl {
@@ -180,13 +179,35 @@ class Literal {
 
   /// <=> for strings.
   inline auto operator<=>(const std::string& _str) const {
+#if __cpp_lib_three_way_comparison >= 201907L
     return name() <=> _str;
+#else
+    auto const &const_name = name();
+    if (const_name < _str) {
+      return std::strong_ordering::less;
+    }
+    if (const_name == _str) {
+      return std::strong_ordering::equal;
+    }
+    return std::strong_ordering::greater;
+#endif
   }
 
   /// <=> for const char*.
   template <internal::StringLiteral... other_fields>
   inline auto operator<=>(const char* _str) const {
+#if __cpp_lib_three_way_comparison >= 201907L
     return name() <=> _str;
+#else
+    auto const &const_name = name();
+    if (const_name < _str) {
+      return std::strong_ordering::less;
+    }
+    if (const_name == _str) {
+      return std::strong_ordering::equal;
+    }
+    return std::strong_ordering::greater;
+#endif
   }
 
   /// Equality operator.

--- a/include/rfl/Validator.hpp
+++ b/include/rfl/Validator.hpp
@@ -1,10 +1,7 @@
 #ifndef RFL_VALIDATOR_HPP_
 #define RFL_VALIDATOR_HPP_
 
-#include <concepts>
 #include <functional>
-#include <optional>
-#include <regex>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -12,12 +9,11 @@
 #include "AllOf.hpp"
 #include "Result.hpp"
 #include "internal/HasValidation.hpp"
-#include "internal/StringLiteral.hpp"
 
 namespace rfl {
 
 template <class T, class V, class... Vs>
-requires internal::HasValidation<AllOf<V, Vs...>, T>
+  requires internal::HasValidation<AllOf<V, Vs...>, T>
 struct Validator {
  public:
   using ReflectionType = T;
@@ -114,7 +110,17 @@ struct Validator {
 template <class T, class V, class... Vs>
 inline auto operator<=>(const Validator<T, V, Vs...>& _v1,
                         const Validator<T, V, Vs...>& _v2) {
+#if __cpp_lib_three_way_comparison >= 201907L
   return _v1.value() <=> _v2.value();
+#else
+  if (_v1.value() < _v2.value()) {
+    return std::strong_ordering::less;
+  } else if (_v1.value() > _v2.value()) {
+    return std::strong_ordering::greater;
+  } else {
+    return std::strong_ordering::equal;
+  }
+#endif
 }
 
 template <class T, class V, class... Vs>

--- a/include/rfl/cbor/Reader.hpp
+++ b/include/rfl/cbor/Reader.hpp
@@ -3,21 +3,12 @@
 
 #include <cbor.h>
 
-#include <array>
-#include <concepts>
 #include <exception>
-#include <map>
-#include <memory>
-#include <source_location>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
-#include "../Box.hpp"
 #include "../Result.hpp"
 #include "../always_false.hpp"
 

--- a/include/rfl/internal/enums/get_enum_names.hpp
+++ b/include/rfl/internal/enums/get_enum_names.hpp
@@ -2,8 +2,11 @@
 #define RFL_INTERNAL_ENUMS_GET_ENUM_NAMES_HPP_
 
 #include <limits>
-#include <source_location>
 #include <type_traits>
+
+#if __has_include(<source_location>)
+#include <source_location>
+#endif
 
 #include "../../Literal.hpp"
 #include "../../define_literal.hpp"
@@ -43,11 +46,11 @@ template <auto e>
 consteval auto get_enum_name_str_view() {
   // Unfortunately, we cannot avoid the use of a compiler-specific macro for
   // Clang on Windows. For all other compilers, function_name works as intended.
-#if defined(__clang__) && defined(_MSC_VER)
-  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
-#else
+#if __cpp_lib_source_location >= 201907L
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#else
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
 #endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 1);

--- a/include/rfl/internal/get_field_names.hpp
+++ b/include/rfl/internal/get_field_names.hpp
@@ -1,18 +1,15 @@
 #ifndef RFL_INTERNAL_GETFIELDNAMES_HPP_
 #define RFL_INTERNAL_GETFIELDNAMES_HPP_
 
-#include <array>
-#include <iostream>
-#include <memory>
-#include <source_location>
-#include <string>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 
+#if __has_include(<source_location>)
+#include <source_location>
+#endif
+
 #include "../Literal.hpp"
 #include "bind_fake_object_to_tuple.hpp"
-#include "get_fake_object.hpp"
 #include "is_flatten_field.hpp"
 #include "is_rename.hpp"
 #include "num_fields.hpp"
@@ -44,11 +41,11 @@ template <class T, auto ptr>
 consteval auto get_field_name_str_view() {
   // Unfortunately, we cannot avoid the use of a compiler-specific macro for
   // Clang on Windows. For all other compilers, function_name works as intended.
-#if defined(__clang__) && defined(_MSC_VER)
-  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
-#else
+#if __cpp_lib_source_location >= 201907L
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#else
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
 #endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 2);

--- a/include/rfl/internal/get_type_name.hpp
+++ b/include/rfl/internal/get_type_name.hpp
@@ -1,9 +1,13 @@
 #ifndef RFL_INTERNAL_GETTYPENAME_HPP_
 #define RFL_INTERNAL_GETTYPENAME_HPP_
 
-#include <source_location>
-#include <string>
 #include <utility>
+
+#include "rfl/internal/StringLiteral.hpp"
+
+#if __has_include(<source_location>)
+#include <source_location>
+#endif
 
 namespace rfl {
 namespace internal {
@@ -12,11 +16,11 @@ template <class T>
 consteval auto get_type_name_str_view() {
   // Unfortunately, we cannot avoid the use of a compiler-specific macro for
   // Clang on Windows. For all other compilers, function_name works as intended.
-#if defined(__clang__) && defined(_MSC_VER)
-  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
-#else
+#if __cpp_lib_source_location >= 201907L
   const auto func_name =
       std::string_view{std::source_location::current().function_name()};
+#else
+  const auto func_name = std::string_view{__PRETTY_FUNCTION__};
 #endif
 #if defined(__clang__)
   const auto split = func_name.substr(0, func_name.size() - 1);

--- a/include/rfl/internal/get_type_name.hpp
+++ b/include/rfl/internal/get_type_name.hpp
@@ -3,7 +3,7 @@
 
 #include <utility>
 
-#include "rfl/internal/StringLiteral.hpp"
+#include "StringLiteral.hpp"
 
 #if __has_include(<source_location>)
 #include <source_location>

--- a/include/rfl/internal/remove_namespaces.hpp
+++ b/include/rfl/internal/remove_namespaces.hpp
@@ -1,7 +1,6 @@
 #ifndef RFL_INTERNAL_REMOVE_NAMESPACES_HPP_
 #define RFL_INTERNAL_REMOVE_NAMESPACES_HPP_
 
-#include <source_location>
 #include <string_view>
 #include <utility>
 

--- a/include/rfl/internal/to_std_array.hpp
+++ b/include/rfl/internal/to_std_array.hpp
@@ -21,7 +21,7 @@ struct StdArrayType<T[_n]> {
 };
 
 template <class T>
-using to_std_array_t = StdArrayType<T>::Type;
+using to_std_array_t = typename StdArrayType<T>::Type;
 
 template <class T>
 auto to_std_array(T&& _t) {

--- a/include/rfl/msgpack/Reader.hpp
+++ b/include/rfl/msgpack/Reader.hpp
@@ -3,21 +3,11 @@
 
 #include <msgpack.h>
 
-#include <array>
-#include <concepts>
 #include <exception>
-#include <map>
-#include <memory>
-#include <source_location>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <unordered_map>
-#include <vector>
 
-#include "../Box.hpp"
 #include "../Result.hpp"
 #include "../always_false.hpp"
 
@@ -30,9 +20,8 @@ struct Reader {
   using InputVarType = msgpack_object;
 
   template <class T>
-  static constexpr bool has_custom_constructor = (requires(InputVarType var) {
-    T::from_msgpack_obj(var);
-  });
+  static constexpr bool has_custom_constructor =
+      (requires(InputVarType var) { T::from_msgpack_obj(var); });
 
   rfl::Result<InputVarType> get_field_from_array(
       const size_t _idx, const InputArrayType _arr) const noexcept {

--- a/include/rfl/parsing/Parser_default.hpp
+++ b/include/rfl/parsing/Parser_default.hpp
@@ -47,7 +47,7 @@ struct Parser {
         using ReflectionType = std::remove_cvref_t<typename T::ReflectionType>;
         const auto wrap_in_t = [](auto _named_tuple) -> Result<T> {
           try {
-            return T(_named_tuple);
+            return T{_named_tuple};
           } catch (std::exception& e) {
             return Error(e.what());
           }

--- a/include/rfl/visit.hpp
+++ b/include/rfl/visit.hpp
@@ -17,7 +17,7 @@ inline auto visit(const Visitor& _visitor, const Literal<_fields...> _literal,
                   const Args&... _args) {
     constexpr int size = sizeof...(_fields);
     using WrapperType = internal::VisitorWrapper<Visitor, _fields...>;
-    const auto wrapper = WrapperType(&_visitor);
+    const auto wrapper = WrapperType{&_visitor};
     return internal::VisitTree::visit<0, size, WrapperType>(
         wrapper, _literal.value(), _args...);
 }

--- a/tests/bson/test_add_struct_name.cpp
+++ b/tests/bson/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_array.cpp
+++ b/tests/bson/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/bson.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/bson/test_box.cpp
+++ b/tests/bson/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_combined_processors.cpp
+++ b/tests/bson/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_custom_class1.cpp
+++ b/tests/bson/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_custom_class3.cpp
+++ b/tests/bson/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_custom_class4.cpp
+++ b/tests/bson/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_default_values.cpp
+++ b/tests/bson/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_deque.cpp
+++ b/tests/bson/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_enum.cpp
+++ b/tests/bson/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_field_variant.cpp
+++ b/tests/bson/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_flag_enum.cpp
+++ b/tests/bson/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_flag_enum_with_int.cpp
+++ b/tests/bson/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_flatten.cpp
+++ b/tests/bson/test_flatten.cpp
@@ -1,9 +1,6 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/bson/test_flatten_anonymous.cpp
+++ b/tests/bson/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_forward_list.cpp
+++ b/tests/bson/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_literal.cpp
+++ b/tests/bson/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_literal_map.cpp
+++ b/tests/bson/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/bson/test_map.cpp
+++ b/tests/bson/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/bson/test_map_with_key_validation.cpp
+++ b/tests/bson/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/bson/test_monster_example.cpp
+++ b/tests/bson/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_oid.cpp
+++ b/tests/bson/test_oid.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_readme_example.cpp
+++ b/tests/bson/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_readme_example2.cpp
+++ b/tests/bson/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_ref.cpp
+++ b/tests/bson/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_save_load.cpp
+++ b/tests/bson/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/bson.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_set.cpp
+++ b/tests/bson/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_size.cpp
+++ b/tests/bson/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_snake_case_to_camel_case.cpp
+++ b/tests/bson/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_snake_case_to_pascal_case.cpp
+++ b/tests/bson/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_string_map.cpp
+++ b/tests/bson/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/bson/test_tagged_union.cpp
+++ b/tests/bson/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_timestamp.cpp
+++ b/tests/bson/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_unique_ptr.cpp
+++ b/tests/bson/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_unique_ptr2.cpp
+++ b/tests/bson/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_variant.cpp
+++ b/tests/bson/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/bson/test_wstring.cpp
+++ b/tests/bson/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_add_struct_name.cpp
+++ b/tests/cbor/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_array.cpp
+++ b/tests/cbor/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/cbor.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/cbor/test_box.cpp
+++ b/tests/cbor/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_combined_processors.cpp
+++ b/tests/cbor/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_custom_class1.cpp
+++ b/tests/cbor/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_custom_class3.cpp
+++ b/tests/cbor/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_custom_class4.cpp
+++ b/tests/cbor/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_default_values.cpp
+++ b/tests/cbor/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_deque.cpp
+++ b/tests/cbor/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_enum.cpp
+++ b/tests/cbor/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_field_variant.cpp
+++ b/tests/cbor/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_flag_enum.cpp
+++ b/tests/cbor/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_flag_enum_with_int.cpp
+++ b/tests/cbor/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_flatten.cpp
+++ b/tests/cbor/test_flatten.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_flatten_anonymous.cpp
+++ b/tests/cbor/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_forward_list.cpp
+++ b/tests/cbor/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_literal.cpp
+++ b/tests/cbor/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_literal_map.cpp
+++ b/tests/cbor/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/cbor/test_map.cpp
+++ b/tests/cbor/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/cbor/test_map_with_key_validation.cpp
+++ b/tests/cbor/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/cbor/test_monster_example.cpp
+++ b/tests/cbor/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_readme_example.cpp
+++ b/tests/cbor/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_readme_example2.cpp
+++ b/tests/cbor/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_ref.cpp
+++ b/tests/cbor/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_save_load.cpp
+++ b/tests/cbor/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/cbor.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_set.cpp
+++ b/tests/cbor/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_size.cpp
+++ b/tests/cbor/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_snake_case_to_camel_case.cpp
+++ b/tests/cbor/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_snake_case_to_pascal_case.cpp
+++ b/tests/cbor/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_string_map.cpp
+++ b/tests/cbor/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/cbor/test_tagged_union.cpp
+++ b/tests/cbor/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_tagged_union2.cpp
+++ b/tests/cbor/test_tagged_union2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_timestamp.cpp
+++ b/tests/cbor/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_unique_ptr.cpp
+++ b/tests/cbor/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_unique_ptr2.cpp
+++ b/tests/cbor/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_variant.cpp
+++ b/tests/cbor/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/cbor/test_wstring.cpp
+++ b/tests/cbor/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_add_struct_name.cpp
+++ b/tests/flexbuffers/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_array.cpp
+++ b/tests/flexbuffers/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/flexbuf.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/flexbuffers/test_box.cpp
+++ b/tests/flexbuffers/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_combined_processors.cpp
+++ b/tests/flexbuffers/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_custom_class1.cpp
+++ b/tests/flexbuffers/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_custom_class3.cpp
+++ b/tests/flexbuffers/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_custom_class4.cpp
+++ b/tests/flexbuffers/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_default_values.cpp
+++ b/tests/flexbuffers/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_deque.cpp
+++ b/tests/flexbuffers/test_deque.cpp
@@ -1,8 +1,5 @@
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 
@@ -24,6 +21,5 @@ TEST(flexbuf, test_default_values) {
       Person{.first_name = "Homer", .children = std::move(children)};
 
   write_and_read(homer);
-
 }
 }  // namespace test_deque

--- a/tests/flexbuffers/test_enum.cpp
+++ b/tests/flexbuffers/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_field_variant.cpp
+++ b/tests/flexbuffers/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_flag_enum.cpp
+++ b/tests/flexbuffers/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_flag_enum_with_int.cpp
+++ b/tests/flexbuffers/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_flatten.cpp
+++ b/tests/flexbuffers/test_flatten.cpp
@@ -1,9 +1,6 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/flexbuffers/test_flatten_anonymous.cpp
+++ b/tests/flexbuffers/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_forward_list.cpp
+++ b/tests/flexbuffers/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_literal.cpp
+++ b/tests/flexbuffers/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_literal_map.cpp
+++ b/tests/flexbuffers/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/flexbuffers/test_map.cpp
+++ b/tests/flexbuffers/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/flexbuffers/test_map_with_key_validation.cpp
+++ b/tests/flexbuffers/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/flexbuffers/test_monster_example.cpp
+++ b/tests/flexbuffers/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_readme_example.cpp
+++ b/tests/flexbuffers/test_readme_example.cpp
@@ -1,6 +1,4 @@
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_readme_example2.cpp
+++ b/tests/flexbuffers/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_ref.cpp
+++ b/tests/flexbuffers/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_save_load.cpp
+++ b/tests/flexbuffers/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/flexbuf.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_set.cpp
+++ b/tests/flexbuffers/test_set.cpp
@@ -1,8 +1,5 @@
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 
@@ -14,7 +11,7 @@ struct Person {
   std::unique_ptr<std::set<std::string>> children;
 };
 
-TEST(flexbuf, test_set) { 
+TEST(flexbuf, test_set) {
   auto children = std::make_unique<std::set<std::string>>(
       std::set<std::string>({"Bart", "Lisa", "Maggie"}));
 

--- a/tests/flexbuffers/test_size.cpp
+++ b/tests/flexbuffers/test_size.cpp
@@ -1,6 +1,4 @@
-#include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 
@@ -17,7 +15,7 @@ struct Person {
       children;
 };
 
-TEST(flexbuf, test_size) { 
+TEST(flexbuf, test_size) {
   const auto bart = Person{
       .first_name = "Bart", .last_name = "Simpson", .birthday = "1987-04-19"};
 

--- a/tests/flexbuffers/test_snake_case_to_camel_case.cpp
+++ b/tests/flexbuffers/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_snake_case_to_pascal_case.cpp
+++ b/tests/flexbuffers/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_string_map.cpp
+++ b/tests/flexbuffers/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/flexbuffers/test_tagged_union.cpp
+++ b/tests/flexbuffers/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_tagged_union2.cpp
+++ b/tests/flexbuffers/test_tagged_union2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_timestamp.cpp
+++ b/tests/flexbuffers/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_unique_ptr.cpp
+++ b/tests/flexbuffers/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_unique_ptr2.cpp
+++ b/tests/flexbuffers/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_variant.cpp
+++ b/tests/flexbuffers/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/flexbuffers/test_wstring.cpp
+++ b/tests/flexbuffers/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_add_struct_name.cpp
+++ b/tests/json/test_add_struct_name.cpp
@@ -1,7 +1,5 @@
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_all_of.cpp
+++ b/tests/json/test_all_of.cpp
@@ -1,8 +1,5 @@
-#include <iostream>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 // Make sure things still compile when
 // rfl.hpp is included after rfl/json.hpp.

--- a/tests/json/test_alphanumeric_map.cpp
+++ b/tests/json/test_alphanumeric_map.cpp
@@ -1,9 +1,7 @@
-#include <iostream>
 #include <map>
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_alphanumeric_unordered_map.cpp
+++ b/tests/json/test_alphanumeric_unordered_map.cpp
@@ -1,8 +1,6 @@
-#include <iostream>
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/json/test_and_then.cpp
+++ b/tests/json/test_and_then.cpp
@@ -1,10 +1,6 @@
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <type_traits>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_anonymous_fields.cpp
+++ b/tests/json/test_anonymous_fields.cpp
@@ -1,7 +1,5 @@
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_any_of.cpp
+++ b/tests/json/test_any_of.cpp
@@ -1,9 +1,6 @@
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_apply.cpp
+++ b/tests/json/test_apply.cpp
@@ -1,11 +1,8 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <type_traits>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_array.cpp
+++ b/tests/json/test_array.cpp
@@ -1,10 +1,8 @@
 
 #include <array>
-#include <iostream>
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_as.cpp
+++ b/tests/json/test_as.cpp
@@ -1,10 +1,7 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 
@@ -27,7 +24,6 @@ struct C {
 };
 
 TEST(json, test_as) {
-
   auto a = A{.f1 = "Hello", .f2 = rfl::make_box<std::string>("World")};
 
   auto b = B{.f3 = "Hello", .f4 = rfl::make_box<std::string>("World")};

--- a/tests/json/test_as2.cpp
+++ b/tests/json/test_as2.cpp
@@ -1,10 +1,7 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_as_flatten.cpp
+++ b/tests/json/test_as_flatten.cpp
@@ -1,10 +1,7 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_box.cpp
+++ b/tests/json/test_box.cpp
@@ -1,10 +1,7 @@
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/json/test_box2.cpp
+++ b/tests/json/test_box2.cpp
@@ -1,12 +1,9 @@
+#include <gtest/gtest.h>
+
 #include <cassert>
-#include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
-#include <vector>
-
-#include <gtest/gtest.h>
 
 namespace test_box2 {
 
@@ -16,5 +13,5 @@ TEST(json, test_box2) {
       rfl::make_box<std::string>(std::move(ptr));
 
   ASSERT_TRUE(box && true);
- }
+}
 }  // namespace test_box2

--- a/tests/json/test_c_array_class1.cpp
+++ b/tests/json/test_c_array_class1.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <source_location>
 #include <string>
 
 #include "rfl.hpp"

--- a/tests/json/test_c_array_class2.cpp
+++ b/tests/json/test_c_array_class2.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <source_location>
 #include <string>
 
 #include "rfl.hpp"

--- a/tests/json/test_c_array_class3.cpp
+++ b/tests/json/test_c_array_class3.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <source_location>
 
 #include "rfl.hpp"
 #include "rfl/json.hpp"

--- a/tests/json/test_c_array_class4.cpp
+++ b/tests/json/test_c_array_class4.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <source_location>
 
 #include "rfl.hpp"
 #include "rfl/json.hpp"

--- a/tests/json/test_c_array_class5.cpp
+++ b/tests/json/test_c_array_class5.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <source_location>
 
 #include "rfl.hpp"
 #include "rfl/json.hpp"

--- a/tests/json/test_combined_processors.cpp
+++ b/tests/json/test_combined_processors.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_const_fields.cpp
+++ b/tests/json/test_const_fields.cpp
@@ -2,7 +2,6 @@
 #include <optional>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_custom_class1.cpp
+++ b/tests/json/test_custom_class1.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_custom_class2.cpp
+++ b/tests/json/test_custom_class2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/tests/json/test_custom_class3.cpp
+++ b/tests/json/test_custom_class3.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_custom_class4.cpp
+++ b/tests/json/test_custom_class4.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_custom_constructor.cpp
+++ b/tests/json/test_custom_constructor.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_default_values.cpp
+++ b/tests/json/test_default_values.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_deque.cpp
+++ b/tests/json/test_deque.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_email.cpp
+++ b/tests/json/test_email.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_empty_object.cpp
+++ b/tests/json/test_empty_object.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum1.cpp
+++ b/tests/json/test_enum1.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum2.cpp
+++ b/tests/json/test_enum2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum3.cpp
+++ b/tests/json/test_enum3.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum4.cpp
+++ b/tests/json/test_enum4.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum5.cpp
+++ b/tests/json/test_enum5.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum6.cpp
+++ b/tests/json/test_enum6.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_enum7.cpp
+++ b/tests/json/test_enum7.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_error_messages.cpp
+++ b/tests/json/test_error_messages.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_field_variant.cpp
+++ b/tests/json/test_field_variant.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_flag_enum1.cpp
+++ b/tests/json/test_flag_enum1.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_flag_enum2.cpp
+++ b/tests/json/test_flag_enum2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_flag_enum_with_int.cpp
+++ b/tests/json/test_flag_enum_with_int.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_flatten.cpp
+++ b/tests/json/test_flatten.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_flatten_anonymous.cpp
+++ b/tests/json/test_flatten_anonymous.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_forward_list.cpp
+++ b/tests/json/test_forward_list.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_inheritance.cpp
+++ b/tests/json/test_inheritance.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <tuple>
 
 namespace test_inheritance {

--- a/tests/json/test_inheritance2.cpp
+++ b/tests/json/test_inheritance2.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 
 #include "rfl/internal/num_fields.hpp"
 

--- a/tests/json/test_inside_function.cpp
+++ b/tests/json/test_inside_function.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_json_schema.cpp
+++ b/tests/json/test_json_schema.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <tuple>
 #include <variant>

--- a/tests/json/test_json_schema2.cpp
+++ b/tests/json/test_json_schema2.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <tuple>
 #include <variant>

--- a/tests/json/test_json_schema3.cpp
+++ b/tests/json/test_json_schema3.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <tuple>
 #include <variant>

--- a/tests/json/test_list.cpp
+++ b/tests/json/test_list.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_literal.cpp
+++ b/tests/json/test_literal.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_literal_map.cpp
+++ b/tests/json/test_literal_map.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/json/test_literal_unordered_map.cpp
+++ b/tests/json/test_literal_unordered_map.cpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/json/test_map.cpp
+++ b/tests/json/test_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_map_with_key_validation.cpp
+++ b/tests/json/test_map_with_key_validation.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_monster_example.cpp
+++ b/tests/json/test_monster_example.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_move_replace.cpp
+++ b/tests/json/test_move_replace.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_multimap.cpp
+++ b/tests/json/test_multimap.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_multiset.cpp
+++ b/tests/json/test_multiset.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_no_optionals.cpp
+++ b/tests/json/test_no_optionals.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_one_of.cpp
+++ b/tests/json/test_one_of.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_optional_fields.cpp
+++ b/tests/json/test_optional_fields.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_readme_example.cpp
+++ b/tests/json/test_readme_example.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_ref.cpp
+++ b/tests/json/test_ref.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace.cpp
+++ b/tests/json/test_replace.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace2.cpp
+++ b/tests/json/test_replace2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace_flatten.cpp
+++ b/tests/json/test_replace_flatten.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace_flatten2.cpp
+++ b/tests/json/test_replace_flatten2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace_with_other_struct.cpp
+++ b/tests/json/test_replace_with_other_struct.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_replace_with_other_struct2.cpp
+++ b/tests/json/test_replace_with_other_struct2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_result.cpp
+++ b/tests/json/test_result.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_save_load.cpp
+++ b/tests/json/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_set.cpp
+++ b/tests/json/test_set.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_shared_ptr.cpp
+++ b/tests/json/test_shared_ptr.cpp
@@ -2,7 +2,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_size.cpp
+++ b/tests/json/test_size.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_skip.cpp
+++ b/tests/json/test_skip.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_snake_case_to_camel_case.cpp
+++ b/tests/json/test_snake_case_to_camel_case.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_snake_case_to_camel_case_rename.cpp
+++ b/tests/json/test_snake_case_to_camel_case_rename.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_snake_case_to_pascal_case.cpp
+++ b/tests/json/test_snake_case_to_pascal_case.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_snake_case_to_pascal_case_rename.cpp
+++ b/tests/json/test_snake_case_to_pascal_case_rename.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_std_ref.cpp
+++ b/tests/json/test_std_ref.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include <gtest/gtest.h>

--- a/tests/json/test_string_map.cpp
+++ b/tests/json/test_string_map.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_string_unordered_map.cpp
+++ b/tests/json/test_string_unordered_map.cpp
@@ -2,7 +2,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/json/test_strip_field_names.cpp
+++ b/tests/json/test_strip_field_names.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_tagged_union.cpp
+++ b/tests/json/test_tagged_union.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_tagged_union2.cpp
+++ b/tests/json/test_tagged_union2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_tagged_union3.cpp
+++ b/tests/json/test_tagged_union3.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_tagged_union4.cpp
+++ b/tests/json/test_tagged_union4.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_template.cpp
+++ b/tests/json/test_template.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_timestamp.cpp
+++ b/tests/json/test_timestamp.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_transform.cpp
+++ b/tests/json/test_transform.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/tests/json/test_unique_ptr.cpp
+++ b/tests/json/test_unique_ptr.cpp
@@ -2,7 +2,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_unique_ptr2.cpp
+++ b/tests/json/test_unique_ptr2.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_unnamed_namespace.cpp
+++ b/tests/json/test_unnamed_namespace.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_unordered_map.cpp
+++ b/tests/json/test_unordered_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/json/test_unordered_multimap.cpp
+++ b/tests/json/test_unordered_multimap.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/json/test_unordered_multiset.cpp
+++ b/tests/json/test_unordered_multiset.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_unordered_set.cpp
+++ b/tests/json/test_unordered_set.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_variant.cpp
+++ b/tests/json/test_variant.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/json/test_view.cpp
+++ b/tests/json/test_view.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/tests/json/test_wstring.cpp
+++ b/tests/json/test_wstring.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/msgpack/test_add_struct_name.cpp
+++ b/tests/msgpack/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_array.cpp
+++ b/tests/msgpack/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/msgpack.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/msgpack/test_box.cpp
+++ b/tests/msgpack/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_combined_processors.cpp
+++ b/tests/msgpack/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_custom_class1.cpp
+++ b/tests/msgpack/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_custom_class3.cpp
+++ b/tests/msgpack/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_custom_class4.cpp
+++ b/tests/msgpack/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_default_values.cpp
+++ b/tests/msgpack/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_deque.cpp
+++ b/tests/msgpack/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_enum.cpp
+++ b/tests/msgpack/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_field_variant.cpp
+++ b/tests/msgpack/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_flag_enum.cpp
+++ b/tests/msgpack/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_flag_enum_with_int.cpp
+++ b/tests/msgpack/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_flatten.cpp
+++ b/tests/msgpack/test_flatten.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_flatten_anonymous.cpp
+++ b/tests/msgpack/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_forward_list.cpp
+++ b/tests/msgpack/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_literal.cpp
+++ b/tests/msgpack/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_literal_map.cpp
+++ b/tests/msgpack/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/msgpack/test_map.cpp
+++ b/tests/msgpack/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/msgpack/test_map_with_key_validation.cpp
+++ b/tests/msgpack/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/msgpack/test_monster_example.cpp
+++ b/tests/msgpack/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_readme_example.cpp
+++ b/tests/msgpack/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_readme_example2.cpp
+++ b/tests/msgpack/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_ref.cpp
+++ b/tests/msgpack/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_save_load.cpp
+++ b/tests/msgpack/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/msgpack.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_set.cpp
+++ b/tests/msgpack/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_size.cpp
+++ b/tests/msgpack/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_skip.cpp
+++ b/tests/msgpack/test_skip.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_snake_case_to_camel_case.cpp
+++ b/tests/msgpack/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_snake_case_to_pascal_case.cpp
+++ b/tests/msgpack/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_string_map.cpp
+++ b/tests/msgpack/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/msgpack/test_tagged_union.cpp
+++ b/tests/msgpack/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_tagged_union2.cpp
+++ b/tests/msgpack/test_tagged_union2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_timestamp.cpp
+++ b/tests/msgpack/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_unique_ptr.cpp
+++ b/tests/msgpack/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_unique_ptr2.cpp
+++ b/tests/msgpack/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_variant.cpp
+++ b/tests/msgpack/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/msgpack/test_wstring.cpp
+++ b/tests/msgpack/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_add_struct_name.cpp
+++ b/tests/toml/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_array.cpp
+++ b/tests/toml/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/toml.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/toml/test_box.cpp
+++ b/tests/toml/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_combined_processors.cpp
+++ b/tests/toml/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_custom_class1.cpp
+++ b/tests/toml/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_custom_class3.cpp
+++ b/tests/toml/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_custom_class4.cpp
+++ b/tests/toml/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_default_values.cpp
+++ b/tests/toml/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_deque.cpp
+++ b/tests/toml/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_enum.cpp
+++ b/tests/toml/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_field_variant.cpp
+++ b/tests/toml/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_flag_enum.cpp
+++ b/tests/toml/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_flag_enum_with_int.cpp
+++ b/tests/toml/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_flatten.cpp
+++ b/tests/toml/test_flatten.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_flatten_anonymous.cpp
+++ b/tests/toml/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_forward_list.cpp
+++ b/tests/toml/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_literal.cpp
+++ b/tests/toml/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_literal_map.cpp
+++ b/tests/toml/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/toml/test_map.cpp
+++ b/tests/toml/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/toml/test_map_with_key_validation.cpp
+++ b/tests/toml/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/toml/test_monster_example.cpp
+++ b/tests/toml/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_readme_example.cpp
+++ b/tests/toml/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_readme_example2.cpp
+++ b/tests/toml/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_ref.cpp
+++ b/tests/toml/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_save_load.cpp
+++ b/tests/toml/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/toml.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_set.cpp
+++ b/tests/toml/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_size.cpp
+++ b/tests/toml/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_snake_case_to_camel_case.cpp
+++ b/tests/toml/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_snake_case_to_pascal_case.cpp
+++ b/tests/toml/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_string_map.cpp
+++ b/tests/toml/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/toml/test_tagged_union.cpp
+++ b/tests/toml/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_timestamp.cpp
+++ b/tests/toml/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_unique_ptr.cpp
+++ b/tests/toml/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_unique_ptr2.cpp
+++ b/tests/toml/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_variant.cpp
+++ b/tests/toml/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/toml/test_wstring.cpp
+++ b/tests/toml/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_add_struct_name.cpp
+++ b/tests/xml/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_array.cpp
+++ b/tests/xml/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/xml.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/xml/test_box.cpp
+++ b/tests/xml/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_combined_processors.cpp
+++ b/tests/xml/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_custom_class1.cpp
+++ b/tests/xml/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_custom_class3.cpp
+++ b/tests/xml/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_custom_class4.cpp
+++ b/tests/xml/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_default_values.cpp
+++ b/tests/xml/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_deque.cpp
+++ b/tests/xml/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_enum.cpp
+++ b/tests/xml/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_field_variant.cpp
+++ b/tests/xml/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_flag_enum.cpp
+++ b/tests/xml/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_flag_enum_with_int.cpp
+++ b/tests/xml/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_flatten.cpp
+++ b/tests/xml/test_flatten.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_flatten_anonymous.cpp
+++ b/tests/xml/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_forward_list.cpp
+++ b/tests/xml/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_literal.cpp
+++ b/tests/xml/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_literal_map.cpp
+++ b/tests/xml/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/xml/test_map.cpp
+++ b/tests/xml/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/xml/test_map_with_key_validation.cpp
+++ b/tests/xml/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/xml/test_monster_example.cpp
+++ b/tests/xml/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_readme_example.cpp
+++ b/tests/xml/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_readme_example2.cpp
+++ b/tests/xml/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_ref.cpp
+++ b/tests/xml/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_save_load.cpp
+++ b/tests/xml/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/xml.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_set.cpp
+++ b/tests/xml/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_size.cpp
+++ b/tests/xml/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_snake_case_to_camel_case.cpp
+++ b/tests/xml/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_snake_case_to_pascal_case.cpp
+++ b/tests/xml/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_string_map.cpp
+++ b/tests/xml/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/xml/test_tagged_union.cpp
+++ b/tests/xml/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_timestamp.cpp
+++ b/tests/xml/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_unique_ptr.cpp
+++ b/tests/xml/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_unique_ptr2.cpp
+++ b/tests/xml/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_variant.cpp
+++ b/tests/xml/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_wstring.cpp
+++ b/tests/xml/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_xml_content.cpp
+++ b/tests/xml/test_xml_content.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/xml/test_xml_content2.cpp
+++ b/tests/xml/test_xml_content2.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_add_struct_name.cpp
+++ b/tests/yaml/test_add_struct_name.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_array.cpp
+++ b/tests/yaml/test_array.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl/yaml.hpp>
-#include <source_location>
 #include <string>
 
 // Make sure things still compile when

--- a/tests/yaml/test_box.cpp
+++ b/tests/yaml/test_box.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_combined_processors.cpp
+++ b/tests/yaml/test_combined_processors.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_custom_class1.cpp
+++ b/tests/yaml/test_custom_class1.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_custom_class3.cpp
+++ b/tests/yaml/test_custom_class3.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_custom_class4.cpp
+++ b/tests/yaml/test_custom_class4.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_default_values.cpp
+++ b/tests/yaml/test_default_values.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_deque.cpp
+++ b/tests/yaml/test_deque.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_enum.cpp
+++ b/tests/yaml/test_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_field_variant.cpp
+++ b/tests/yaml/test_field_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_flag_enum.cpp
+++ b/tests/yaml/test_flag_enum.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_flag_enum_with_int.cpp
+++ b/tests/yaml/test_flag_enum_with_int.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_flatten.cpp
+++ b/tests/yaml/test_flatten.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_flatten_anonymous.cpp
+++ b/tests/yaml/test_flatten_anonymous.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_forward_list.cpp
+++ b/tests/yaml/test_forward_list.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_literal.cpp
+++ b/tests/yaml/test_literal.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_literal_map.cpp
+++ b/tests/yaml/test_literal_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <unordered_map>
 

--- a/tests/yaml/test_map.cpp
+++ b/tests/yaml/test_map.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/yaml/test_map_with_key_validation.cpp
+++ b/tests/yaml/test_map_with_key_validation.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <map>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/yaml/test_monster_example.cpp
+++ b/tests/yaml/test_monster_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_readme_example.cpp
+++ b/tests/yaml/test_readme_example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_readme_example2.cpp
+++ b/tests/yaml/test_readme_example2.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_ref.cpp
+++ b/tests/yaml/test_ref.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_save_load.cpp
+++ b/tests/yaml/test_save_load.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <rfl/yaml.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_set.cpp
+++ b/tests/yaml/test_set.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_size.cpp
+++ b/tests/yaml/test_size.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_snake_case_to_camel_case.cpp
+++ b/tests/yaml/test_snake_case_to_camel_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_snake_case_to_pascal_case.cpp
+++ b/tests/yaml/test_snake_case_to_pascal_case.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_string_map.cpp
+++ b/tests/yaml/test_string_map.cpp
@@ -2,7 +2,6 @@
 #include <map>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 
 #include "write_and_read.hpp"

--- a/tests/yaml/test_tagged_union.cpp
+++ b/tests/yaml/test_tagged_union.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_timestamp.cpp
+++ b/tests/yaml/test_timestamp.cpp
@@ -1,7 +1,6 @@
 #include <ctime>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_unique_ptr.cpp
+++ b/tests/yaml/test_unique_ptr.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <memory>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_unique_ptr2.cpp
+++ b/tests/yaml/test_unique_ptr2.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_variant.cpp
+++ b/tests/yaml/test_variant.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/tests/yaml/test_wstring.cpp
+++ b/tests/yaml/test_wstring.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <rfl.hpp>
-#include <source_location>
 #include <string>
 #include <vector>
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "simdjson",
-      "version>=": "3.6.2"
+      "version>=": "3.9.3"
     },
     {
       "name": "tinycbor",
@@ -68,9 +68,9 @@
     }
   ],
   "overrides": [
-     {
-        "name": "yyjson", 
-        "version": "0.8.0"
-     }
+    {
+      "name": "yyjson",
+      "version": "0.8.0"
+    }
   ]
 }


### PR DESCRIPTION
 Compatibility GCC14:
- upgrade simdjson (https://github.com/simdjson/simdjson/issues/2116, https://github.com/simdjson/simdjson/issues/2175)
  
Compatibility clang14:
- wrap source_location and move unused includes
- use constructor via {}
- <=> in three ways
-  add missing typename

Compatibility vcpkg (https://github.com/microsoft/vcpkg/pull/38899):
- be an interface library if being header-only / without bundled dependencies
