### PR TITLE
simdjson inlining and idiomaticity in benchmark

### DIFF
--- a/benchmarks/json/canada.cpp
+++ b/benchmarks/json/canada.cpp
@@ -220,22 +220,26 @@ simdjson_inline std::vector<std::vector<std::tuple<double, double>>> simdjson_to
   return coordinates;
 }
 
+simdjson_inline std::string simdjson_to_string(simdjson::ondemand::value _val) {
+  return std::string(std::string_view(_val));
+}
+
 simdjson_inline Property simdjson_to_property(simdjson::ondemand::object _val) {
   Property property;
-  property.name = _val["name"].get_string().value();
+  property.name = std::string_view(_val["name"]);
   return property;
 }
 
 simdjson_inline Geometry simdjson_to_geometry(simdjson::ondemand::object _val) {
   Geometry geometry;
-  geometry.type = std::string(_val["type"].get_string().value());
+  geometry.type = simdjson_to_string(_val["type"]);
   geometry.coordinates = simdjson_to_coordinates(_val["coordinates"]);
   return geometry;
 }
 
 simdjson_inline Feature simdjson_to_feature(simdjson::ondemand::object _val) {
   Feature feature;
-  feature.type = std::string(_val["type"].get_string().value());
+  feature.type = simdjson_to_string(_val["type"]);
   feature.properties = simdjson_to_property(_val["properties"]);
   feature.geometry = simdjson_to_geometry(_val["geometry"]);
   return feature;
@@ -244,7 +248,7 @@ simdjson_inline Feature simdjson_to_feature(simdjson::ondemand::object _val) {
 simdjson_inline FeatureCollection simdjson_to_feature_collection(
     simdjson::ondemand::object _val) {
   FeatureCollection feature_collection;
-  feature_collection.type = std::string(_val["type"].get_string().value());
+  feature_collection.type = simdjson_to_string(_val["type"]);
   for (auto val : _val["features"].get_array()) {
     feature_collection.features.push_back(simdjson_to_feature(val));
   }

--- a/benchmarks/json/canada.cpp
+++ b/benchmarks/json/canada.cpp
@@ -207,7 +207,7 @@ simdjson_inline std::vector<std::vector<std::tuple<double, double>>> simdjson_to
   std::vector<std::vector<std::tuple<double, double>>> coordinates;
   for (auto arr1 : _val) {
     std::vector<std::tuple<double, double>> vec;
-    for (auto val2 : arr1.get_array()) {
+    for (auto val2 : arr1) {
       // Instead of indexing x = val2[0] and y = val2[1], we iterate through the two values.
       auto coord = val2.begin();
       double x = *coord;
@@ -229,16 +229,15 @@ simdjson_inline Property simdjson_to_property(simdjson::ondemand::object _val) {
 simdjson_inline Geometry simdjson_to_geometry(simdjson::ondemand::object _val) {
   Geometry geometry;
   geometry.type = std::string(_val["type"].get_string().value());
-  geometry.coordinates =
-      simdjson_to_coordinates(_val["coordinates"].get_array());
+  geometry.coordinates = simdjson_to_coordinates(_val["coordinates"]);
   return geometry;
 }
 
 simdjson_inline Feature simdjson_to_feature(simdjson::ondemand::object _val) {
   Feature feature;
   feature.type = std::string(_val["type"].get_string().value());
-  feature.properties = simdjson_to_property(_val["properties"].get_object());
-  feature.geometry = simdjson_to_geometry(_val["geometry"].get_object());
+  feature.properties = simdjson_to_property(_val["properties"]);
+  feature.geometry = simdjson_to_geometry(_val["geometry"]);
   return feature;
 }
 
@@ -257,8 +256,8 @@ static rfl::Result<FeatureCollection> read_using_simdjson(
   try {
     simdjson::ondemand::parser parser;
     auto padded_str = simdjson::padded_string(_json_string);
-    auto doc = parser.iterate(padded_str).value();
-    return simdjson_to_feature_collection(doc.get_object());
+    auto doc = parser.iterate(padded_str);
+    return simdjson_to_feature_collection(doc);
   } catch (std::exception &e) {
     return rfl::Error(e.what());
   }

--- a/benchmarks/json/canada.cpp
+++ b/benchmarks/json/canada.cpp
@@ -208,11 +208,12 @@ simdjson_inline std::vector<std::vector<std::tuple<double, double>>> simdjson_to
   for (auto arr1 : _val) {
     std::vector<std::tuple<double, double>> vec;
     for (auto val2 : arr1.get_array()) {
-      auto arr2 = val2.get_array();
-      std::tuple<double, double> tup;
-      std::get<0>(tup) = arr2.at(0).get_double();
-      std::get<1>(tup) = arr2.at(1).get_double();
-      vec.emplace_back(std::move(tup));
+      // Instead of indexing x = val2[0] and y = val2[1], we iterate through the two values.
+      auto coord = val2.begin();
+      double x = *coord;
+      ++coord;
+      double y = *coord;
+      vec.emplace_back(x, y);
     }
     coordinates.emplace_back(std::move(vec));
   }

--- a/benchmarks/json/canada.cpp
+++ b/benchmarks/json/canada.cpp
@@ -190,19 +190,19 @@ static rfl::Result<FeatureCollection> read_using_rapidjson(
 // ----------------------------------------------------------------------------
 // simdjson
 
-std::vector<std::vector<std::tuple<double, double>>> simdjson_to_coordinates(
+simdjson_inline std::vector<std::vector<std::tuple<double, double>>> simdjson_to_coordinates(
     simdjson::ondemand::array _val);
 
-Property simdjson_to_property(simdjson::ondemand::object _val);
+simdjson_inline Property simdjson_to_property(simdjson::ondemand::object _val);
 
-Geometry simdjson_to_geometry(simdjson::ondemand::object _val);
+simdjson_inline Geometry simdjson_to_geometry(simdjson::ondemand::object _val);
 
-Feature simdjson_to_feature(simdjson::ondemand::object _val);
+simdjson_inline Feature simdjson_to_feature(simdjson::ondemand::object _val);
 
-FeatureCollection simdjson_to_feature_collection(
+simdjson_inline FeatureCollection simdjson_to_feature_collection(
     simdjson::ondemand::object _val);
 
-std::vector<std::vector<std::tuple<double, double>>> simdjson_to_coordinates(
+simdjson_inline std::vector<std::vector<std::tuple<double, double>>> simdjson_to_coordinates(
     simdjson::ondemand::array _val) {
   std::vector<std::vector<std::tuple<double, double>>> coordinates;
   for (auto arr1 : _val) {
@@ -219,13 +219,13 @@ std::vector<std::vector<std::tuple<double, double>>> simdjson_to_coordinates(
   return coordinates;
 }
 
-Property simdjson_to_property(simdjson::ondemand::object _val) {
+simdjson_inline Property simdjson_to_property(simdjson::ondemand::object _val) {
   Property property;
   property.name = _val["name"].get_string().value();
   return property;
 }
 
-Geometry simdjson_to_geometry(simdjson::ondemand::object _val) {
+simdjson_inline Geometry simdjson_to_geometry(simdjson::ondemand::object _val) {
   Geometry geometry;
   geometry.type = std::string(_val["type"].get_string().value());
   geometry.coordinates =
@@ -233,7 +233,7 @@ Geometry simdjson_to_geometry(simdjson::ondemand::object _val) {
   return geometry;
 }
 
-Feature simdjson_to_feature(simdjson::ondemand::object _val) {
+simdjson_inline Feature simdjson_to_feature(simdjson::ondemand::object _val) {
   Feature feature;
   feature.type = std::string(_val["type"].get_string().value());
   feature.properties = simdjson_to_property(_val["properties"].get_object());
@@ -241,7 +241,7 @@ Feature simdjson_to_feature(simdjson::ondemand::object _val) {
   return feature;
 }
 
-FeatureCollection simdjson_to_feature_collection(
+simdjson_inline FeatureCollection simdjson_to_feature_collection(
     simdjson::ondemand::object _val) {
   FeatureCollection feature_collection;
   feature_collection.type = std::string(_val["type"].get_string().value());


### PR DESCRIPTION
This doesn't really make simdjson any faster than BSON or other formats, but it does bring it back in line with my expectations around performance :) After this, canada.json is the same or faster than yyjson on my machine (but only by pennies!), and remains faster on the other benchmarks.

The two changes that made the difference:

1. Inlining the deserialization methods. On Demand is explicitly designed to take advantage of inlining.
2. Reading the coordinate tuple [1,2] with an iterator instead of indexing it as an array.

I also removed some unnecessary boilerplate .value() and .get_array/object() methods.

NOTE: simdjson could get some small perf gains if `rfl::Literal` took a string_view constructor; the fact that it takes a `std::string` means we're forced to allocate every time we see a `type`, when all it really needs to do is compare the string to a static list and put the integer index in there. This seems like it would a generally positive change to reflect-cpp anyway :)