### PR TITLE
Fix typo in custom parser docs

### DIFF
--- a/docs/custom_parser.md
+++ b/docs/custom_parser.md
@@ -78,7 +78,7 @@ You then implement the custom parser:
 namespace rfl::parsing {
 
 template <class ReaderType, class WriterType, class ProcessorsType>
-struct Parser<ReaderType, WriterType, Person>
+struct Parser<ReaderType, WriterType, Person, ProcessorsType>
     : public CustomParser<ReaderType, WriterType, ProcessorsType, Person, PersonImpl> {};
 
 }  // namespace rfl::parsing


### PR DESCRIPTION
For the example to compile, the `ProcessorsType` needs to be passed though to the custom perser's template params?