### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ const auto view = rfl::to_view(lisa);
 *rfl::get<"first_name">(view) = "Maggie";
 
 view.apply([](const auto& f) {
-  // f is a an rfl::Field pointing to the original field.
+  // f is an rfl::Field pointing to the original field.
   std::cout << f.name() << ": " << rfl::json::write(*f.value()) << std::endl;
 });
 ```


### PR DESCRIPTION
A tiny typo, but because the documentation standard is otherwise so high, I thought it worth fixing :)