### PR TITLE
fix: incorrect json schema for size validated fields

### DIFF
--- a/include/rfl/Size.hpp
+++ b/include/rfl/Size.hpp
@@ -22,7 +22,10 @@ struct Size {
 
   template <class T>
   static parsing::schema::ValidationType to_schema() {
-    return V::template to_schema<size_t>();
+    using ValidationType = parsing::schema::ValidationType;
+    return ValidationType{ValidationType::Size{
+        .size_limit_ =
+            rfl::Ref<ValidationType>::make(V::template to_schema<size_t>())}};
   }
 };
 

--- a/include/rfl/json/schema/Type.hpp
+++ b/include/rfl/json/schema/Type.hpp
@@ -32,6 +32,8 @@ struct Type {
   struct String {
     Literal<"string"> type;
     std::optional<std::string> description;
+    rfl::Rename<"minLength", std::optional<size_t>> minSize;
+    rfl::Rename<"maxLength", std::optional<size_t>> maxSize;
   };
 
   using NumericType = std::variant<Integer, Number>;
@@ -62,8 +64,8 @@ struct Type {
     Literal<"array"> type;
     std::optional<std::string> description;
     rfl::Ref<Type> items;
-    size_t minContains;
-    size_t maxContains;
+    size_t minItems;
+    size_t maxItems;
   };
 
   struct Maximum {
@@ -130,6 +132,8 @@ struct Type {
     Literal<"array"> type;
     std::optional<std::string> description;
     rfl::Ref<Type> items;
+    rfl::Rename<"minItems", std::optional<size_t>> minSize;
+    rfl::Rename<"maxItems", std::optional<size_t>> maxSize;
   };
 
   using ReflectionType =

--- a/tests/json/test_json_schema_size_validation.cpp
+++ b/tests/json/test_json_schema_size_validation.cpp
@@ -1,45 +1,81 @@
-#include <iostream>
+#include <array>
 #include <rfl.hpp>
 #include <rfl/json.hpp>
+#include <set>
 #include <string>
-#include <tuple>
-#include <variant>
 #include <vector>
 
-#include "write_and_read.hpp"
+#include "gtest/gtest.h"
 
 namespace test_json_schema_size_validation {
 
-struct TestStruct {
-  template <typename T, typename... Validators>
-  using SizedAnyOf = rfl::Validator<T, rfl::Size<rfl::AnyOf<Validators...>>>;
-  template <typename T, typename... Validators>
-  using SizedAllOf = rfl::Validator<T, rfl::Size<rfl::AllOf<Validators...>>>;
-  template <typename T, auto Min, auto Max>
-  using SizedMinMax = rfl::Validator<T, rfl::Size<rfl::Minimum<Min>>,
-                                     rfl::Size<rfl::Maximum<Max>>>;
+using rfl::EqualTo;
+using rfl::Maximum;
+using rfl::Minimum;
+using rfl::json::to_schema;
 
-  SizedMinMax<std::string, 1, 2> a;
-  SizedMinMax<std::vector<int>, 2, 3> b;
-  SizedMinMax<std::set<int>, 3, 4> c;
+template <typename T, typename... Validators>
+using SizedAnyOf = rfl::Validator<T, rfl::Size<rfl::AnyOf<Validators...>>>;
+template <typename T, typename... Validators>
+using SizedAllOf = rfl::Validator<T, rfl::Size<rfl::AllOf<Validators...>>>;
+template <typename T, auto Min, auto Max>
+using SizedMinMax =
+    rfl::Validator<T, rfl::Size<Minimum<Min>>, rfl::Size<Maximum<Max>>>;
 
-  SizedAnyOf<std::string, rfl::EqualTo<1>, rfl::EqualTo<3>> d;
-  SizedAnyOf<std::vector<int>, rfl::EqualTo<2>, rfl::EqualTo<4>> e;
-  SizedAnyOf<std::set<int>, rfl::EqualTo<3>, rfl::EqualTo<5>> f;
+TEST(json, test_json_schema_sized_vector_min1_max2) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","allOf":[{"type":"array","items":{"type":"integer"},"minItems":1},{"type":"array","items":{"type":"integer"},"maxItems":2}],"definitions":{}})";
 
-  // AllOf<Size<Minimum<X>>, Size<Maximum<Y>>> expected to be the same as
-  // Size<AllOf<Minimum<X>, Maximum<Y>>>, so a, b, and c should produce the same
-  // schema as g, h, and i
-  SizedAllOf<std::string, rfl::Minimum<1>, rfl::Maximum<2>> g;
-  SizedAllOf<std::vector<int>, rfl::Minimum<2>, rfl::Maximum<3>> h;
-  SizedAllOf<std::set<int>, rfl::Minimum<3>, rfl::Maximum<4>> i;
+  auto actual = to_schema<SizedMinMax<std::vector<int>, 1, 2>>();
+  ASSERT_EQ(expected, actual);
+  actual = to_schema<SizedAllOf<std::vector<int>, Minimum<1>, Maximum<2>>>();
+  ASSERT_EQ(expected, actual);
+}
 
-  std::array<int, 3> j;
-};
+TEST(json, test_json_schema_sized_set_min2_max3) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}],"definitions":{}})";
 
-TEST(json, test_json_schema_size_validation) {
-  constexpr auto expected_schema =
-      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"#/definitions/test_json_schema_size_validation__TestStruct","definitions":{"test_json_schema_size_validation__TestStruct":{"type":"object","properties":{"a":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"b":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"c":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"d":{"anyOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"e":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"f":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"g":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"h":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"i":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"j":{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3}},"required":["a","b","c","d","e","f","g","h","i","j"]}}})";
-  ASSERT_EQ(expected_schema, rfl::json::to_schema<TestStruct>());
+  auto actual = to_schema<SizedMinMax<std::set<int>, 2, 3>>();
+  ASSERT_EQ(expected, actual);
+  actual = to_schema<SizedAllOf<std::set<int>, Minimum<2>, Maximum<3>>>();
+  ASSERT_EQ(expected, actual);
+}
+
+TEST(json, test_json_schema_sized_string_min4_max6) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","allOf":[{"type":"string","minLength":4},{"type":"string","maxLength":6}],"definitions":{}})";
+
+  auto actual = to_schema<SizedMinMax<std::string, 4, 6>>();
+  ASSERT_EQ(expected, actual);
+  actual = to_schema<SizedAllOf<std::string, Minimum<4>, Maximum<6>>>();
+  ASSERT_EQ(expected, actual);
+}
+
+TEST(json, test_json_schema_sized_vector_anyof_eq3_eq7) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","anyOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":7,"maxItems":7}],"definitions":{}})";
+
+  auto actual =
+      to_schema<SizedAnyOf<std::vector<int>, EqualTo<3>, EqualTo<7>>>();
+  ASSERT_EQ(expected, actual);
+}
+
+TEST(json, test_json_schema_sized_set_anyof_eq15_eq16) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","anyOf":[{"type":"array","items":{"type":"integer"},"minItems":16,"maxItems":16},{"type":"array","items":{"type":"integer"},"minItems":16,"maxItems":16}],"definitions":{}})";
+
+  auto actual =
+      to_schema<SizedAnyOf<std::vector<int>, EqualTo<16>, EqualTo<16>>>();
+  ASSERT_EQ(expected, actual);
+}
+
+TEST(json, test_json_schema_sized_string_anyof_eq1_eq10) {
+  constexpr auto expected =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","anyOf":[{"type":"array","items":{"type":"integer"},"minItems":1,"maxItems":1},{"type":"array","items":{"type":"integer"},"minItems":10,"maxItems":10}],"definitions":{}})";
+
+  auto actual =
+      to_schema<SizedAnyOf<std::vector<int>, EqualTo<1>, EqualTo<10>>>();
+  ASSERT_EQ(expected, actual);
 }
 }  // namespace test_json_schema_size_validation

--- a/tests/json/test_json_schema_size_validation.cpp
+++ b/tests/json/test_json_schema_size_validation.cpp
@@ -16,7 +16,8 @@ struct TestStruct {
   template <typename T, typename... Validators>
   using SizedAllOf = rfl::Validator<T, rfl::Size<rfl::AllOf<Validators...>>>;
   template <typename T, auto Min, auto Max>
-  using SizedMinMax = SizedAllOf<T, rfl::Minimum<Min>, rfl::Maximum<Max>>;
+  using SizedMinMax = rfl::Validator<T, rfl::Size<rfl::Minimum<Min>>,
+                                     rfl::Size<rfl::Maximum<Max>>>;
 
   SizedMinMax<std::string, 1, 2> a;
   SizedMinMax<std::vector<int>, 2, 3> b;
@@ -26,16 +27,19 @@ struct TestStruct {
   SizedAnyOf<std::vector<int>, rfl::EqualTo<2>, rfl::EqualTo<4>> e;
   SizedAnyOf<std::set<int>, rfl::EqualTo<3>, rfl::EqualTo<5>> f;
 
-  SizedAllOf<std::string, rfl::EqualTo<1>, rfl::EqualTo<3>> g;
-  SizedAllOf<std::vector<int>, rfl::EqualTo<2>, rfl::EqualTo<4>> h;
-  SizedAllOf<std::set<int>, rfl::EqualTo<3>, rfl::EqualTo<5>> i;
+  // AllOf<Size<Minimum<X>>, Size<Maximum<Y>>> expected to be the same as
+  // Size<AllOf<Minimum<X>, Maximum<Y>>>, so a, b, and c should produce the same
+  // schema as g, h, and i
+  SizedAllOf<std::string, rfl::Minimum<1>, rfl::Maximum<2>> g;
+  SizedAllOf<std::vector<int>, rfl::Minimum<2>, rfl::Maximum<3>> h;
+  SizedAllOf<std::set<int>, rfl::Minimum<3>, rfl::Maximum<4>> i;
 
   std::array<int, 3> j;
-};  
+};
 
 TEST(json, test_json_schema_size_validation) {
   constexpr auto expected_schema =
-      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"#/definitions/test_json_schema_size_validation__TestStruct","definitions":{"test_json_schema_size_validation__TestStruct":{"type":"object","properties":{"a":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"b":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"c":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"d":{"anyOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"e":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"f":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"g":{"allOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"h":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"i":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"j":{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3}},"required":["a","b","c","d","e","f","g","h","i","j"]}}})";
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"#/definitions/test_json_schema_size_validation__TestStruct","definitions":{"test_json_schema_size_validation__TestStruct":{"type":"object","properties":{"a":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"b":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"c":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"d":{"anyOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"e":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"f":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"g":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"h":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"i":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"j":{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3}},"required":["a","b","c","d","e","f","g","h","i","j"]}}})";
   ASSERT_EQ(expected_schema, rfl::json::to_schema<TestStruct>());
 }
 }  // namespace test_json_schema_size_validation

--- a/tests/json/test_json_schema_size_validation.cpp
+++ b/tests/json/test_json_schema_size_validation.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+namespace test_json_schema_size_validation {
+
+struct TestStruct {
+  template <typename T, typename... Validators>
+  using SizedAnyOf = rfl::Validator<T, rfl::Size<rfl::AnyOf<Validators...>>>;
+  template <typename T, typename... Validators>
+  using SizedAllOf = rfl::Validator<T, rfl::Size<rfl::AllOf<Validators...>>>;
+  template <typename T, auto Min, auto Max>
+  using SizedMinMax = SizedAllOf<T, rfl::Minimum<Min>, rfl::Maximum<Max>>;
+
+  SizedMinMax<std::string, 1, 2> a;
+  SizedMinMax<std::vector<int>, 2, 3> b;
+  SizedMinMax<std::set<int>, 3, 4> c;
+
+  SizedAnyOf<std::string, rfl::EqualTo<1>, rfl::EqualTo<3>> d;
+  SizedAnyOf<std::vector<int>, rfl::EqualTo<2>, rfl::EqualTo<4>> e;
+  SizedAnyOf<std::set<int>, rfl::EqualTo<3>, rfl::EqualTo<5>> f;
+
+  SizedAllOf<std::string, rfl::EqualTo<1>, rfl::EqualTo<3>> g;
+  SizedAllOf<std::vector<int>, rfl::EqualTo<2>, rfl::EqualTo<4>> h;
+  SizedAllOf<std::set<int>, rfl::EqualTo<3>, rfl::EqualTo<5>> i;
+
+  std::array<int, 3> j;
+};  
+
+TEST(json, test_json_schema_size_validation) {
+  constexpr auto expected_schema =
+      R"({"$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"#/definitions/test_json_schema_size_validation__TestStruct","definitions":{"test_json_schema_size_validation__TestStruct":{"type":"object","properties":{"a":{"allOf":[{"type":"string","minLength":1},{"type":"string","maxLength":2}]},"b":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2},{"type":"array","items":{"type":"integer"},"maxItems":3}]},"c":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3},{"type":"array","items":{"type":"integer"},"maxItems":4}]},"d":{"anyOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"e":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"f":{"anyOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"g":{"allOf":[{"type":"string","minLength":1,"maxLength":1},{"type":"string","minLength":3,"maxLength":3}]},"h":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":2,"maxItems":2},{"type":"array","items":{"type":"integer"},"minItems":4,"maxItems":4}]},"i":{"allOf":[{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3},{"type":"array","items":{"type":"integer"},"minItems":5,"maxItems":5}]},"j":{"type":"array","items":{"type":"integer"},"minItems":3,"maxItems":3}},"required":["a","b","c","d","e","f","g","h","i","j"]}}})";
+  ASSERT_EQ(expected_schema, rfl::json::to_schema<TestStruct>());
+}
+}  // namespace test_json_schema_size_validation


### PR DESCRIPTION
A fix for the incorrect JSON schema being generated for size validated fields.

At first I was just tinkering around with the library and testing its features, and one thing I was interested in is automatic JSON schema generation. I wanted to be sure my strings would be X characters long, and the library had the support for that, but JSON schema generated for such fields is obviously incorrect.

So for the struct:
```
struct TestStruct
{
    template<typename T, auto Min, auto Max>
    using SizeValidated = rfl::Validator<T, rfl::Size<rfl::Minimum<Min>>, rfl::Size<rfl::Maximum<Max>>>;

    SizeValidated<std::string, 1, 2> a;
};
```
generated schema is:
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "$ref": "#/definitions/TestStruct",
    "definitions": {
        "TestStruct": {
            "type": "object",
            "properties": {
                "a": {
                    "allOf": [
                        {
                            "minimum": 1,
                            "type": "number"
                        },
                        {
                            "maximum": 2,
                            "type": "number"
                        }
                    ]
                }
            ],
            "required": [
                "a"
            ]
        }
    }
}
```
and "a" definitely should not be a "number"

With my fix generated schema is:
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "$ref": "#/definitions/TestStruct",
    "definitions": {
        "TestStruct": {
            "type": "object",
            "properties": {
                "a": {
                    "allOf": [
                        {
                            "type": "string",
                            "minLength": 1
                        },
                        {
                            "type": "string",
                            "maxLength": 2
                        }
                    ]
                }
            ],
            "required": [
                "a"
            ]
        }
    }
}

```

My fix is not the prettiest and needs some work (especially with naming), and I hope you could help me with that. But it works! I couldn't find any more edge cases (e.g. using AnyOf/AllOf inside the Size), so please point out the ones I missed. I'm also attaching a JSON schema generated for
```
struct TestStruct
{
    template<typename T, auto Min, auto Max>
    using SizeValidated = rfl::Validator<T, rfl::Size<rfl::Minimum<Min>>, rfl::Size<rfl::Maximum<Max>>>;

    SizeValidated<std::string, 1, 2> a;
    SizeValidated<std::vector<int>, 1, 2> s;
    SizeValidated<std::set<int>, 1, 2> d;
    SizeValidated<std::map<int, int>, 1, 2> f;
    rfl::Validator<std::string, rfl::Size<rfl::AnyOf<rfl::EqualTo<4>, rfl::EqualTo<6>>>> g;
    rfl::Validator<std::string, rfl::AnyOf<rfl::Size<rfl::EqualTo<4>>, rfl::Size<rfl::EqualTo<6>>>> h;
    rfl::Validator<std::string, rfl::Size<rfl::EqualTo<6>>> j;
};
```
[schema.json](https://github.com/user-attachments/files/16147444/schema.json)