### PR TITLE
feat: optional to/from methods on Reflector. (#150)

### DIFF
--- a/docs/custom_parser.md
+++ b/docs/custom_parser.md
@@ -19,8 +19,11 @@ struct Reflector<Person> {
     return {v.first_name, v.last_name};
   }
 };
-} 
+}
 ```
+
+It's also fine to define just the `from` method when the original class is only written, or `to` when the original class is only read.
+
 
 Alternatively, you can implement a custom parser using `rfl::parsing::CustomParser`.
 

--- a/include/rfl/internal/has_reflection_method_v.hpp
+++ b/include/rfl/internal/has_reflection_method_v.hpp
@@ -4,8 +4,6 @@
 #include <type_traits>
 
 namespace rfl {
-template <typename T>
-struct Reflector;
 namespace internal {
 
 template <typename Wrapper>
@@ -24,13 +22,6 @@ struct has_refl_m<Wrapper, std::void_t<reflection_method_t<Wrapper>>>
 /// called "reflection".
 template <typename Wrapper>
 constexpr bool has_reflection_method_v = has_refl_m<Wrapper>::value;
-
-template <typename Type>
-concept has_reflector = requires(Type&& item) {
-  Reflector<Type>::from(item);
-} && requires(const typename Reflector<Type>::ReflType& item) {
-  Reflector<Type>::to(item);
-};
 
 }  // namespace internal
 }  // namespace rfl

--- a/include/rfl/internal/has_reflector.hpp
+++ b/include/rfl/internal/has_reflector.hpp
@@ -1,0 +1,25 @@
+#ifndef RFL_INTERNAL_HASREFLECTIOR_HPP_
+#define RFL_INTERNAL_HASREFLECTIOR_HPP_
+
+#include <type_traits>
+
+namespace rfl {
+template <typename T>
+struct Reflector;
+
+namespace internal {
+
+template <typename Type>
+concept has_write_reflector = requires(Type&& item) {
+  Reflector<Type>::from(item);
+};
+
+template <typename Type>
+concept has_read_reflector = requires(const typename Reflector<Type>::ReflType& item) {
+  Reflector<Type>::to(item);
+};
+
+}  // namespace internal
+}  // namespace rfl
+
+#endif 

--- a/include/rfl/parsing/Parser_default.hpp
+++ b/include/rfl/parsing/Parser_default.hpp
@@ -9,6 +9,7 @@
 #include "../always_false.hpp"
 #include "../from_named_tuple.hpp"
 #include "../internal/enums/StringConverter.hpp"
+#include "../internal/has_reflector.hpp"
 #include "../internal/has_reflection_method_v.hpp"
 #include "../internal/has_reflection_type_v.hpp"
 #include "../internal/is_basic_type.hpp"
@@ -40,7 +41,7 @@ struct Parser {
 
   /// Expresses the variables as type T.
   static Result<T> read(const R& _r, const InputVarType& _var) noexcept {
-    if constexpr (internal::has_reflector<T>) {
+    if constexpr (internal::has_read_reflector<T>) {
       const auto wrap_in_t = [](auto _named_tuple) -> Result<T> {
         try {
           return Reflector<T>::to(_named_tuple);
@@ -78,7 +79,7 @@ struct Parser {
 
   template <class P>
   static void write(const W& _w, const T& _var, const P& _parent) noexcept {
-    if constexpr (internal::has_reflector<T>) {
+    if constexpr (internal::has_write_reflector<T>) {
       Parser<R, W, typename Reflector<T>::ReflType, ProcessorsType>::write(
           _w, Reflector<T>::from(_var), _parent);
     } else if constexpr (internal::has_reflection_type_v<T>) {

--- a/tests/json/test_reflector_read.cpp
+++ b/tests/json/test_reflector_read.cpp
@@ -1,0 +1,46 @@
+#include <cassert>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+namespace test_reflector_read {
+
+struct Person {
+  std::string first_name = "Homer";
+  std::string last_name = "Simpson";
+};
+
+struct Parent : Person {
+  std::vector<Person> children;
+};
+
+}  // namespace test_reflector_read
+
+namespace rfl {
+template <>
+struct Reflector<test_reflector_read::Parent> {
+  struct ReflType {
+    std::string first_name;
+    std::string last_name;
+    std::vector<test_reflector_read::Person> children;
+  };
+  static test_reflector_read::Parent to(const ReflType& v) noexcept {
+    return {v.first_name, v.last_name, v.children};
+  }
+};
+}  // namespace rfl
+
+namespace test_reflector_read {
+
+TEST(json, test_reflector_read) {
+  const auto homer =
+      test_reflector_read::Parent{"Homer", "Simpson", {{"Bart", "Simpson"}, {"Lisa", "Simpson"}}};
+
+  read(
+      R"({"first_name":"Homer","last_name":"Simpson","children":[{"first_name":"Bart","last_name":"Simpson"},{"first_name":"Lisa","last_name":"Simpson"}]})",
+      homer);
+}
+}  // namespace test_reflector_read

--- a/tests/json/test_reflector_write.cpp
+++ b/tests/json/test_reflector_write.cpp
@@ -6,7 +6,7 @@
 
 #include "write_and_read.hpp"
 
-namespace test_reflector {
+namespace test_reflector_write {
 
 struct Person {
   std::string first_name = "Homer";
@@ -17,34 +17,31 @@ struct Parent : Person {
   std::vector<Person> children;
 };
 
-}  // namespace test_reflector
+}  // namespace test_reflector_write
 
 namespace rfl {
 template <>
-struct Reflector<test_reflector::Parent> {
+struct Reflector<test_reflector_write::Parent> {
   struct ReflType {
     std::string first_name;
     std::string last_name;
-    std::vector<test_reflector::Person> children;
+    std::vector<test_reflector_write::Person> children;
   };
-  static test_reflector::Parent to(const ReflType& v) noexcept {
-    return {v.first_name, v.last_name, v.children};
-  }
 
-  static ReflType from(const test_reflector::Parent& v) {
+  static ReflType from(const test_reflector_write::Parent& v) {
     return {v.first_name, v.last_name, v.children};
   }
 };
 }  // namespace rfl
 
-namespace test_reflector {
+namespace test_reflector_write {
 
-TEST(json, test_reflector) {
+TEST(json, test_reflector_write) {
   const auto homer =
-      test_reflector::Parent{"Homer", "Simpson", {{"Bart", "Simpson"}, {"Lisa", "Simpson"}}};
+      test_reflector_write::Parent{"Homer", "Simpson", {{"Bart", "Simpson"}, {"Lisa", "Simpson"}}};
 
-  write_and_read(
+  write(
       homer,
       R"({"first_name":"Homer","last_name":"Simpson","children":[{"first_name":"Bart","last_name":"Simpson"},{"first_name":"Lisa","last_name":"Simpson"}]})");
 }
-}  // namespace test_reflector
+}  // namespace test_reflector_write

--- a/tests/json/write_and_read.hpp
+++ b/tests/json/write_and_read.hpp
@@ -8,6 +8,43 @@
 #include <string>
 #include <type_traits>
 
+
+template <class... Ps>
+auto write(const auto& _struct, const std::string& _expected) {
+  const auto json_string1 = rfl::json::write<Ps...>(_struct);
+  EXPECT_EQ(json_string1, _expected)
+      << "Test failed on write. Expected:" << std::endl
+      << _expected << std::endl
+      << "Got: " << std::endl
+      << json_string1 << std::endl
+      << std::endl;
+    return json_string1;
+}
+
+
+template <class... Ps>
+void read(const std::string& _json, const auto& _expected) {
+  using T = std::remove_cvref_t<decltype(_expected)>;
+  const auto res = rfl::json::read<T, Ps...>(_json);
+  EXPECT_TRUE(res && true) << "Test failed on read. Error: "
+                           << res.error().value().what();
+}
+
+#if 0
+template <class... Ps>
+void write_and_read(const auto& _struct, const std::string& _expected) {
+  auto json_string1 = write<Ps...>(_struct, _expected);
+  auto res = read<Ps...>(json_string1, _struct);
+  const auto json_string2 = rfl::json::write<Ps...>(res.value());
+  EXPECT_EQ(json_string2, _expected)
+      << "Test failed on read. Expected:" << std::endl
+      << _expected << std::endl
+      << "Got: " << std::endl
+      << json_string2 << std::endl
+      << std::endl;
+}
+#endif
+
 template <class... Ps>
 void write_and_read(const auto& _struct, const std::string& _expected) {
   using T = std::remove_cvref_t<decltype(_struct)>;

--- a/tests/json/write_and_read.hpp
+++ b/tests/json/write_and_read.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <type_traits>
 
-
 template <class... Ps>
 auto write(const auto& _struct, const std::string& _expected) {
   const auto json_string1 = rfl::json::write<Ps...>(_struct);
@@ -18,9 +17,8 @@ auto write(const auto& _struct, const std::string& _expected) {
       << "Got: " << std::endl
       << json_string1 << std::endl
       << std::endl;
-    return json_string1;
+  return json_string1;
 }
-
 
 template <class... Ps>
 void read(const std::string& _json, const auto& _expected) {
@@ -29,21 +27,6 @@ void read(const std::string& _json, const auto& _expected) {
   EXPECT_TRUE(res && true) << "Test failed on read. Error: "
                            << res.error().value().what();
 }
-
-#if 0
-template <class... Ps>
-void write_and_read(const auto& _struct, const std::string& _expected) {
-  auto json_string1 = write<Ps...>(_struct, _expected);
-  auto res = read<Ps...>(json_string1, _struct);
-  const auto json_string2 = rfl::json::write<Ps...>(res.value());
-  EXPECT_EQ(json_string2, _expected)
-      << "Test failed on read. Expected:" << std::endl
-      << _expected << std::endl
-      << "Got: " << std::endl
-      << json_string2 << std::endl
-      << std::endl;
-}
-#endif
 
 template <class... Ps>
 void write_and_read(const auto& _struct, const std::string& _expected) {


### PR DESCRIPTION
Changes:

- Separates the `has_reflector` concept into `has_read_reflector` and `has_write_reflector` to allow allow Reflector types to be just readable, just writable, or both readable and writable.

- Adds test cases. The tests are slightly altered from the original `test_reflector` implementation. They now use a small class hierarchy (`Person` and `Parent`) with fields in each class, which is not supported by default. The Reflector implementation in the tests flattens the hierarchy.  Test cases for Reflector implementations with only the `to` and only the `from` method are present.

- Adds a paragraph to the docs mentioning the user-facing changes.

Fixes issue: #150 