### PR TITLE
add simple precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ endif ()
 
 set_target_properties(reflectcpp PROPERTIES LINKER_LANGUAGE CXX)
 target_sources(reflectcpp PRIVATE ${REFLECT_CPP_SOURCES})
+target_precompile_headers(reflectcpp PRIVATE [["rfl.hpp"]] <iostream> <string> <functional>)
 
 if (REFLECTCPP_BUILD_TESTS)
     if (MSVC)

--- a/benchmarks/all/CMakeLists.txt
+++ b/benchmarks/all/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
     reflect-cpp-all-format-benchmarks 
     ${SOURCES}
 )
+target_precompile_headers(reflect-cpp-all-format-benchmarks PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-all-format-benchmarks SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 target_include_directories(reflect-cpp-all-format-benchmarks SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/tinycbor")

--- a/benchmarks/json/CMakeLists.txt
+++ b/benchmarks/json/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
     reflect-cpp-json-benchmarks 
     ${SOURCES}
 )
+target_precompile_headers(reflect-cpp-json-benchmarks PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-json-benchmarks SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/bson/CMakeLists.txt
+++ b/tests/bson/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-bson-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-bson-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/cbor/CMakeLists.txt
+++ b/tests/cbor/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-cbor-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-cbor-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 target_include_directories(reflect-cpp-cbor-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/tinycbor")

--- a/tests/flexbuffers/CMakeLists.txt
+++ b/tests/flexbuffers/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-flexbuffers-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-flexbuffers-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/json/CMakeLists.txt
+++ b/tests/json/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-json-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-json-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/json_c_arrays_and_inheritance/CMakeLists.txt
+++ b/tests/json_c_arrays_and_inheritance/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-json-c-arrays-and-inheritance-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DREFLECT_CPP_C_ARRAYS_OR_INHERITANCE")
 

--- a/tests/msgpack/CMakeLists.txt
+++ b/tests/msgpack/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-msgpack-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-msgpack-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/toml/CMakeLists.txt
+++ b/tests/toml/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-toml-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-toml-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/xml/CMakeLists.txt
+++ b/tests/xml/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-xml-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-xml-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 

--- a/tests/yaml/CMakeLists.txt
+++ b/tests/yaml/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
     ${SOURCES}
     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/src/gtest_main.cc"
 )
+target_precompile_headers(reflect-cpp-yaml-tests PRIVATE [["rfl.hpp"]] <iostream> <string> <functional> <gtest/gtest.h>)
 
 target_include_directories(reflect-cpp-yaml-tests SYSTEM PRIVATE "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 


### PR DESCRIPTION
Cuts tests and benchmarks build time by ~30%
Does not affect library users