### PR TITLE
Fixed issue where 32 bit compilation cause template type deduction fail

### DIFF
--- a/include/rfl/parsing/call_destructors_where_necessary.hpp
+++ b/include/rfl/parsing/call_destructors_where_necessary.hpp
@@ -43,7 +43,7 @@ void call_destructor_on_one_if_necessary(const std::array<bool, _size>& _set,
   }
 }
 
-template <class ViewType, unsigned long _size>
+template <class ViewType, auto _size>
 void call_destructors_where_necessary(const std::array<bool, _size>& _set,
                                       ViewType* _view) {
   [&]<int... is>(std::integer_sequence<int, is...>) {


### PR DESCRIPTION
There was a compilation error when building on 32 bit platforms. I assume it is because `std::size_t` used for `std::array<T, std::size_t N>` is an `unsigned long` on 64 bit and `unsigned int` on 32 bit. 

See this for a quick demonstration: https://godbolt.org/z/xcrdjM5Ks