### PR TITLE
Timestamp: Update workaround to support MinGW alongside MSVC

### DIFF
--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -76,20 +76,6 @@ class Timestamp {
   const std::tm& tm() const { return tm_; }
 
  private:
-#ifdef _MSC_VER
-  // This workaround is necessary, because MSVC doesn't support strptime.
-  char* strptime(const char* _s, const char* _f, std::tm* _tm) {
-    std::istringstream input(_s);
-    input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
-    input >> std::get_time(_tm, _f);
-    if (input.fail()) {
-      return NULL;
-    }
-    return (char*)(_s + input.tellg());
-  }
-#endif
-
- private:
   /// The underlying time stamp.
   std::tm tm_;
 };

--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -25,9 +25,8 @@ class Timestamp {
   Timestamp() : tm_(std::tm{}) {}
 
   Timestamp(const char* _str) : tm_(std::tm{}) {
-    std::istringstream ss(_str);
-    ss >> std::get_time(&tm_, _format.str().c_str());
-    if (ss.fail()) {
+    const auto r = strptime(_str, _format.str().c_str(), &tm_);
+    if (r == NULL) {
       throw std::runtime_error("String '" + std::string(_str) +
                                "' did not match format '" + Format().str() +
                                "'.");

--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -3,9 +3,6 @@
 
 #include <ctime>
 #include <iomanip>
-#include <iostream>
-#include <iterator>
-#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -72,8 +72,8 @@ class Timestamp {
   const std::tm& tm() const { return tm_; }
 
  private:
-#ifdef _MSC_VER
-  // This workaround is necessary, because MSVC doesn't support strptime.
+#if defined(_MSC_VER) || defined(__MINGW32__)
+  // This workaround is necessary, because strptime is not available on Windows.
   char* strptime(const char* _s, const char* _f, std::tm* _tm) {
     std::istringstream input(_s);
     input.imbue(std::locale(setlocale(LC_ALL, nullptr)));

--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -28,8 +28,9 @@ class Timestamp {
   Timestamp() : tm_(std::tm{}) {}
 
   Timestamp(const char* _str) : tm_(std::tm{}) {
-    const auto r = strptime(_str, _format.str().c_str(), &tm_);
-    if (r == NULL) {
+    std::istringstream ss(_str);
+    ss >> std::get_time(&tm_, _format.str().c_str());
+    if (ss.fail()) {
       throw std::runtime_error("String '" + std::string(_str) +
                                "' did not match format '" + Format().str() +
                                "'.");

--- a/include/rfl/Timestamp.hpp
+++ b/include/rfl/Timestamp.hpp
@@ -73,6 +73,20 @@ class Timestamp {
   const std::tm& tm() const { return tm_; }
 
  private:
+#ifdef _MSC_VER
+  // This workaround is necessary, because MSVC doesn't support strptime.
+  char* strptime(const char* _s, const char* _f, std::tm* _tm) {
+    std::istringstream input(_s);
+    input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+    input >> std::get_time(_tm, _f);
+    if (input.fail()) {
+      return NULL;
+    }
+    return (char*)(_s + input.tellg());
+  }
+#endif
+
+ private:
   /// The underlying time stamp.
   std::tm tm_;
 };


### PR DESCRIPTION
Original
---
Timestamp: Replace `strptime` with `std::get_time` for better compatibility

The `strptime` function is a POSIX extension, not universally supported by all compilers (e.g., MSVC). Replacing it with `std::get_time`, which is part of the C++ standard, improves cross-platform compatibility without sacrificing functionality.

Edit
---

`std::get_time` has poor performance compared to `strptime`. My issue was that MinGW failed to compile `reflect-cpp` due to the lack of `strptime`. A more precise solution is to extend the existing workaround to cover MinGW, while keeping `strptime` for better performance on supported platforms.