### PR TITLE
Json read string view

### DIFF
--- a/include/rfl/json/read.hpp
+++ b/include/rfl/json/read.hpp
@@ -8,7 +8,6 @@
 #endif
 
 #include <istream>
-#include <string>
 #include <string_view>
 
 #include "../Processors.hpp"

--- a/include/rfl/json/read.hpp
+++ b/include/rfl/json/read.hpp
@@ -9,6 +9,7 @@
 
 #include <istream>
 #include <string>
+#include <string_view>
 
 #include "../Processors.hpp"
 #include "../internal/wrap_in_rfl_array_t.hpp"
@@ -30,8 +31,8 @@ auto read(const InputVarType& _obj) {
 
 /// Parses an object from JSON using reflection.
 template <class T, class... Ps>
-Result<internal::wrap_in_rfl_array_t<T>> read(const std::string& _json_str) {
-  yyjson_doc* doc = yyjson_read(_json_str.c_str(), _json_str.size(), 0);
+Result<internal::wrap_in_rfl_array_t<T>> read(std::string_view const _json_str) {
+  yyjson_doc* doc = yyjson_read(_json_str.data(), _json_str.size(), 0);
   if (!doc) {
     return Error("Could not parse document");
   }


### PR DESCRIPTION
Hi, this is a very simple PR to change rfl::json::read to use std::string_view instead of std::string. This allows JSON to be read in a zero-copy way when e.g. one has a const char*. Because std::string_view can be implicitly constructed from std::string, the change should have no impact on existing user code.

I verified that all json parser tests pass with this change. 
