### PR TITLE
Add versioning in CMake for shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,13 @@ if (REFLECTCPP_USE_VCPKG)
     set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake CACHE STRING "Vcpkg toolchain file")
 endif ()
 
-project(reflectcpp LANGUAGES CXX)
+project(reflectcpp VERSION 0.16.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 
 if (REFLECTCPP_BUILD_SHARED)
     add_library(reflectcpp SHARED)
+    set_target_properties(reflectcpp PROPERTIES SOVERSION ${PROJECT_VERSION})
 else()
     add_library(reflectcpp STATIC)
 endif()


### PR DESCRIPTION
### Title: Add versioning in CMake for shared library

### Description:
Hello,
I propose this change to enable building reflect-cpp with Yocto.

### Issue:
Without this change, the following error occurs during the build process:

```
ERROR: reflect-cpp-0.16.0-r0 do_package_qa: QA Issue: -dev package reflect-cpp-dev contains non-symlink .so '/usr/lib/libreflectcpp.so' [dev-elf]
ERROR: reflect-cpp-0.16.0-r0 do_package_qa: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /workdir/tmp/work/cortexa55-xware-linux/reflect-cpp/0.16.0/temp/log.do_package_qa.1139088
ERROR: Task (/workdir/layers/meta-xhello/recipes-core/reflect-cpp/reflect-cpp_0.16.0.bb:do_package_qa) failed with exit code '1'
```

### Solution:
With this change, the package builds correctly with the proper SOVERSION. Yocto can locate the original .so file in the main package and create a symlink in the *-dev package.