### PR TITLE
`rfl::Generic`: add support for long (int64)

### DIFF
--- a/include/rfl/Generic.hpp
+++ b/include/rfl/Generic.hpp
@@ -19,10 +19,10 @@ class Generic {
 
   using Array = std::vector<Generic>;
   using Object = rfl::Object<Generic>;
-  using VariantType = std::variant<bool, int, double, std::string, Object,
+  using VariantType = std::variant<bool, int, long, double, std::string, Object,
                                    Array, std::nullopt_t>;
   using ReflectionType = std::optional<
-      std::variant<bool, int, double, std::string, Object, Array>>;
+      std::variant<bool, int, long, double, std::string, Object, Array>>;
 
   Generic();
 
@@ -94,6 +94,10 @@ class Generic {
   /// underlying value is not an integer.
   Result<int> to_int() const noexcept;
 
+  /// Casts the underlying value to a long or returns an rfl::Error, if the
+  /// underlying value is not a long.
+  Result<long> to_long() const noexcept;
+
   /// Casts the underlying value to an rfl::Generic::Object or returns an
   /// rfl::Error, if the underlying value is not an rfl::Generic::Object.
   Result<Object> to_object() const noexcept;
@@ -138,6 +142,10 @@ inline Result<double> to_double(const Generic& _g) noexcept {
 /// Casts the underlying value to an integer or returns an rfl::Error, if the
 /// underlying value is not an integer.
 inline Result<int> to_int(const Generic& _g) noexcept { return _g.to_int(); }
+
+/// Casts the underlying value to a long or returns an rfl::Error, if the
+/// underlying value is not a long.
+inline Result<long> to_long(const Generic& _g) noexcept { return _g.to_long(); }
 
 /// Casts the underlying value to an rfl::Generic::Object or returns an
 /// rfl::Error, if the underlying value is not an rfl::Generic::Object.

--- a/include/rfl/Generic.hpp
+++ b/include/rfl/Generic.hpp
@@ -19,10 +19,10 @@ class Generic {
 
   using Array = std::vector<Generic>;
   using Object = rfl::Object<Generic>;
-  using VariantType = std::variant<bool, int, long, double, std::string, Object,
+  using VariantType = std::variant<bool, long, int, double, std::string, Object,
                                    Array, std::nullopt_t>;
   using ReflectionType = std::optional<
-      std::variant<bool, int, long, double, std::string, Object, Array>>;
+      std::variant<bool, long, int, double, std::string, Object, Array>>;
 
   Generic();
 

--- a/include/rfl/generic/Reader.hpp
+++ b/include/rfl/generic/Reader.hpp
@@ -44,8 +44,13 @@ struct Reader {
       return _var.to_double().transform(
           [](const auto& _v) { return static_cast<T>(_v); });
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      return _var.to_int().transform(
-          [](const auto& _v) { return static_cast<T>(_v); });
+      if constexpr (std::is_same<std::remove_cvref_t<T>, long>()) {
+        return _var.to_long().transform(
+            [](const auto& _v) { return static_cast<T>(_v); });
+      } else {
+        return _var.to_int().transform(
+            [](const auto& _v) { return static_cast<T>(_v); });
+      }
     } else {
       static_assert(rfl::always_false_v<T>, "Unsupported type.");
     }

--- a/include/rfl/generic/Reader.hpp
+++ b/include/rfl/generic/Reader.hpp
@@ -44,7 +44,7 @@ struct Reader {
       return _var.to_double().transform(
           [](const auto& _v) { return static_cast<T>(_v); });
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      if constexpr (std::is_same<std::remove_cvref_t<T>, long>()) {
+      if constexpr (sizeof(T) > sizeof(int)) {
         return _var.to_long().transform(
             [](const auto& _v) { return static_cast<T>(_v); });
       } else {

--- a/include/rfl/generic/Writer.hpp
+++ b/include/rfl/generic/Writer.hpp
@@ -101,7 +101,7 @@ struct Writer {
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       return OutputVarType(static_cast<double>(_var));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      if constexpr (std::is_same<std::remove_cvref_t<T>, long>()) {
+      if constexpr sizeof(T) > sizeof(int) {
         return OutputVarType(static_cast<long>(_var));
       } else {
         return OutputVarType(static_cast<int>(_var));

--- a/include/rfl/generic/Writer.hpp
+++ b/include/rfl/generic/Writer.hpp
@@ -101,7 +101,7 @@ struct Writer {
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       return OutputVarType(static_cast<double>(_var));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      if constexpr sizeof(T) > sizeof(int) {
+      if constexpr (sizeof(T) > sizeof(int)) {
         return OutputVarType(static_cast<long>(_var));
       } else {
         return OutputVarType(static_cast<int>(_var));

--- a/include/rfl/generic/Writer.hpp
+++ b/include/rfl/generic/Writer.hpp
@@ -101,7 +101,11 @@ struct Writer {
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       return OutputVarType(static_cast<double>(_var));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
-      return OutputVarType(static_cast<int>(_var));
+      if constexpr (std::is_same<std::remove_cvref_t<T>, long>()) {
+        return OutputVarType(static_cast<long>(_var));
+      } else {
+        return OutputVarType(static_cast<int>(_var));
+      }
     } else {
       static_assert(always_false_v<T>, "Unsupported type");
     }

--- a/src/rfl/Generic.cpp
+++ b/src/rfl/Generic.cpp
@@ -111,6 +111,15 @@ Result<int> Generic::to_int() const noexcept {
   }
 }
 
+Result<long> Generic::to_long() const noexcept {
+  if (const long* ptr = std::get_if<long>(&value_)) {
+    return *ptr;
+  } else {
+    return Error(
+        "rfl::Generic: Could not cast the underlying value to a long.");
+  }
+}
+
 Result<Generic::Object> Generic::to_object() const noexcept {
   if (const auto* ptr = std::get_if<Object>(&value_)) {
     return *ptr;

--- a/src/rfl/Generic.cpp
+++ b/src/rfl/Generic.cpp
@@ -105,6 +105,8 @@ Result<double> Generic::to_double() const noexcept {
 Result<int> Generic::to_int() const noexcept {
   if (const int* ptr = std::get_if<int>(&value_)) {
     return *ptr;
+  } else if (const long* ptr = std::get_if<long>(&value_)) {
+    return static_cast<int>(*ptr);
   } else {
     return Error(
         "rfl::Generic: Could not cast the underlying value to an integer.");
@@ -114,6 +116,8 @@ Result<int> Generic::to_int() const noexcept {
 Result<long> Generic::to_long() const noexcept {
   if (const long* ptr = std::get_if<long>(&value_)) {
     return *ptr;
+  } else if (const int* ptr = std::get_if<int>(&value_)) {
+    return static_cast<long>(*ptr);
   } else {
     return Error(
         "rfl::Generic: Could not cast the underlying value to a long.");


### PR DESCRIPTION
While working on code that converts `rfl::Generic` to JSON and back, I found that `reflect-cpp@v0.17.0` does not properly convert int64's through Generic. Namely, Generic is defined as a variant with `int` as one option, which causes the JSON parser to cast yyjson values to `int`, potentially truncating the number.

This change introduces `long` as a variant option under Generic. It is placed before `int` to prioritize converting numbers as the bigger variant in the JSON parser, as otherwise the parser will indiscriminately match all integers to int. However, this likely has the side effect where all ints are now treated as longs. As a corrective measure, `to_int` and `to_long` will fall back and static cast from the other type if the variant does not directly match. I was usure of the impact of upgrading the variant's int to long (instead of the proposed implementation of adding a new variant), but perhaps replacing int with long would be cleaner?

If an alternative implementation would be better, please let me know!