### PR TITLE
Parser_default: Move temporary variable instead of copying

### DIFF
--- a/include/rfl/parsing/Parser_default.hpp
+++ b/include/rfl/parsing/Parser_default.hpp
@@ -69,7 +69,7 @@ struct Parser {
         using ReflectionType = std::remove_cvref_t<typename T::ReflectionType>;
         const auto wrap_in_t = [](auto _named_tuple) -> Result<T> {
           try {
-            return T{_named_tuple};
+            return T{std::move(_named_tuple)};
           } catch (std::exception& e) {
             return Error(e.what());
           }

--- a/tests/json/test_movable.cpp
+++ b/tests/json/test_movable.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <iostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+
+struct MoveableType {
+    int x;
+
+
+    MoveableType(MoveableType&&) = default;
+    MoveableType(const MoveableType&) = delete;
+
+    using ReflectionType = int;
+    MoveableType(int&& x) : x(x) {}
+    int reflection() const { return x; }
+};
+
+TEST(json, test_moveable) {
+    MoveableType moveable = {2};
+
+    write_and_read(
+        moveable, R"(2)");
+}


### PR DESCRIPTION
This eliminates an unnecessary copy of a temporary variable which prohibits use of a move-only construction of reflection-types.