### PR TITLE
Add enum range support with customizable min and max values

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -27,34 +27,42 @@ This results in the following JSON string:
 
 However, some limitations apply:
 
-1. They must be be scoped enumerations.
+1. They must be scoped enumerations.
 
-```cpp
-/// OK - scoped enumeration
-enum class Color1 { red, green, blue, yellow };
+    ```cpp
+    /// OK - scoped enumeration
+    enum class Color1 { red, green, blue, yellow };
+    
+    /// OK - scoped enumeration
+    enum struct Color2 { red, green, blue, yellow };
+    
+    /// unsupported - unscoped enumerations
+    enum Color3 { red, green, blue, yellow };
+    ```
 
-/// OK - scoped enumeration
-enum struct Color2 { red, green, blue, yellow };
+2. Enum values must be in the range `[RFL_ENUM_RANGE_MIN, RFL_ENUM_RANGE_MAX]`. If the range is not specified, the
+   default range is `[0, 127]`.
 
-/// unsupported - unscoped enumerations
-enum Color3 { red, green, blue, yellow };
-```
+    - You can specify a custom range for the all enum values by defining `RFL_ENUM_RANGE_MIN` and `RFL_ENUM_RANGE_MAX`
+      before including the reflect-cpp header:
 
-2. You cannot have more than 128 values and if you explicitly assign values, they must be between 0 and 127.
-
-```cpp
-/// OK
-enum class Color1 { red, green, blue, yellow };
-
-/// OK
-enum struct Color2 { red, green, blue = 50, yellow };
-
-/// unsupported - red is a negative value
-enum Color3 { red = -10, green, blue, yellow };
-
-/// unsupported - red is greater than 127
-enum Color3 { red = 200, green, blue, yellow };
-```
+        ```cpp
+        #define RFL_ENUM_RANGE_MIN -128
+        #define RFL_ENUM_RANGE_MAX 128
+        #include <rfl.hpp>
+        ```
+    - You can specify a custom range for a specific enum by defining the specialization `rfl::config::enum_range` for
+      the enum type :
+        ```cpp
+     
+        enum class Color { yellow = 200, purple = 300, orange = 400 };
+     
+        template <>
+        struct rfl::config::enum_range<Color> {
+          static constexpr int min = 200;
+          static constexpr int max = 400;
+        };
+        ```
 
 ## Flag enums
 

--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -59,6 +59,16 @@ constexpr auto get_underlying_enumerator_array() {
   return internal::enums::names_to_underlying_enumerator_array(names);
 }
 
+// Returns the range of the given enum type as a pair of the minimum and maximum
+template <internal::enums::is_scoped_enum EnumType>
+constexpr auto get_enum_range() {
+  return std::make_pair(
+      internal::enums::get_range_min<EnumType,
+                                     internal::enums::is_flag_enum<EnumType>>(),
+      internal::enums::get_range_max<
+          EnumType, internal::enums::is_flag_enum<EnumType>>());
+}
+
 }  // namespace rfl
 
 #endif  // RFL_ENUMS_HPP_

--- a/include/rfl/internal/enums/Names.hpp
+++ b/include/rfl/internal/enums/Names.hpp
@@ -86,6 +86,17 @@ template <class EnumType, class LiteralType, size_t N, bool _is_flag,
             _is_flag, _enums..., _new_enum>>;
 };
 
+
+template <class EnumType, class LiteralType1, size_t N1, bool _is_flag1,
+          auto... _enums1, class LiteralType2, size_t N2, auto... _enums2>
+consteval auto operator|(
+    Names<EnumType, LiteralType1, N1, _is_flag1, _enums1...>,
+    Names<EnumType, LiteralType2, N2, _is_flag1, _enums2...>) {
+  using CombinedLiteral = define_literal_t<LiteralType1, LiteralType2>;
+  return Names<EnumType, CombinedLiteral, N1 + N2, _is_flag1,
+              _enums1..., _enums2...>{};
+}
+
 template <class EnumType, size_t N, bool _is_flag, StringLiteral... _names,
           auto... _enums>
 auto names_to_enumerator_named_tuple(

--- a/include/rfl/internal/enums/Names.hpp
+++ b/include/rfl/internal/enums/Names.hpp
@@ -14,8 +14,55 @@
 #include "../StringLiteral.hpp"
 
 namespace rfl {
+
+// Enum values must be greater than or equal to RFL_ENUM_RANGE_MIN.
+// By default, RFL_ENUM_RANGE_MIN is set to 0.
+// To change the default minimum range for all enum types, redefine the macro
+// RFL_ENUM_RANGE_MIN.
+#if !defined(RFL_ENUM_RANGE_MIN)
+#define RFL_ENUM_RANGE_MIN 0
+#endif
+
+// Enum values must be less than or equal to RFL_ENUM_RANGE_MAX.
+// By default, RFL_ENUM_RANGE_MAX is set to 127.
+// To change the default maximum range for all enum types, redefine the macro
+// RFL_ENUM_RANGE_MAX.
+#if !defined(RFL_ENUM_RANGE_MAX)
+#define RFL_ENUM_RANGE_MAX 127
+#endif
+
+namespace config {
+
+// To specify a different range for a particular enum type, specialize the
+// enum_range template for that enum type.
+template <typename T>
+struct enum_range {
+  static constexpr int min = RFL_ENUM_RANGE_MIN;
+  static constexpr int max = RFL_ENUM_RANGE_MAX;
+};
+}  // namespace config
+
 namespace internal {
 namespace enums {
+
+static_assert(RFL_ENUM_RANGE_MAX > RFL_ENUM_RANGE_MIN,
+              "RFL_ENUM_RANGE_MAX must be greater than RFL_ENUM_RANGE_MIN.");
+
+template <typename T, typename = void>
+struct range_min : std::integral_constant<int, RFL_ENUM_RANGE_MIN> {};
+
+template <typename T>
+struct range_min<T, std::void_t<decltype(config::enum_range<T>::min)>>
+    : std::integral_constant<decltype(config::enum_range<T>::min),
+                             config::enum_range<T>::min> {};
+
+template <typename T, typename = void>
+struct range_max : std::integral_constant<int, RFL_ENUM_RANGE_MAX> {};
+
+template <typename T>
+struct range_max<T, std::void_t<decltype(config::enum_range<T>::max)>>
+    : std::integral_constant<decltype(config::enum_range<T>::max),
+                             config::enum_range<T>::max> {};
 
 template <class EnumType, class LiteralType, size_t N, auto... _enums>
 struct Names {

--- a/include/rfl/internal/enums/get_enum_names.hpp
+++ b/include/rfl/internal/enums/get_enum_names.hpp
@@ -89,12 +89,22 @@ consteval T calc_greatest_power_of_two() {
 }
 
 template <class T, bool _is_flag>
-consteval T get_max() {
+consteval auto get_range_min() {
+  using U = std::underlying_type_t<T>;
   if constexpr (_is_flag) {
-    return calc_greatest_power_of_two<T>();
+    return 0;
   } else {
-    return std::numeric_limits<T>::max() > 127 ? static_cast<T>(127)
-                                               : std::numeric_limits<T>::max();
+    return std::max(std::numeric_limits<U>::min(), range_min<T>::value);
+  }
+}
+
+template <class T, bool _is_flag>
+consteval auto get_range_max() {
+  using U = std::underlying_type_t<T>;
+  if constexpr (_is_flag) {
+    return calc_greatest_power_of_two<U>();
+  } else {
+    return std::min(std::numeric_limits<U>::max(), range_max<T>::value);
   }
 }
 
@@ -142,11 +152,17 @@ consteval auto get_enum_names() {
   static_assert(std::is_integral_v<std::underlying_type_t<EnumType>>,
                 "The underlying type of any Enum must be integral!");
 
-  constexpr auto max = get_max<std::underlying_type_t<EnumType>, _is_flag>();
+  constexpr auto max = get_range_max<EnumType, _is_flag>();
+  constexpr auto min = get_range_min<EnumType, _is_flag>();
+
+  constexpr auto range_size = max - min + 1;
+  static_assert(range_size > 0,
+                "enum_range requires a valid range size. Ensure that "
+                "max is greater than min.");
 
   using EmptyNames = Names<EnumType, rfl::Literal<"">, 0>;
 
-  return get_enum_names_impl<EnumType, EmptyNames, max, _is_flag, 0>();
+  return get_enum_names_impl<EnumType, EmptyNames, max, _is_flag, min>();
 }
 
 }  // namespace enums

--- a/tests/generic/test_enum.cpp
+++ b/tests/generic/test_enum.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <rfl.hpp>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 

--- a/tests/generic/test_enum_range.cpp
+++ b/tests/generic/test_enum_range.cpp
@@ -1,11 +1,9 @@
 #include <cassert>
-#include <iostream>
 // Redefine the range of the enums
 #define RFL_ENUM_RANGE_MIN -128
 #define RFL_ENUM_RANGE_MAX 128
 #include <rfl.hpp>
 #include <string>
-#include <vector>
 
 #include "write_and_read.hpp"
 
@@ -31,25 +29,10 @@ struct rfl::config::enum_range<test_enum_range::LineColor> {
 
 namespace test_enum_range {
 
-TEST(generic, test_enum_range_get_min_max) {
-  auto inner_color_range = rfl::get_enum_range<InnerColor>();
-  EXPECT_EQ(inner_color_range.first, RFL_ENUM_RANGE_MIN);
-  EXPECT_EQ(inner_color_range.second, RFL_ENUM_RANGE_MAX);
-
-  auto line_color_range = rfl::get_enum_range<LineColor>();
-  EXPECT_EQ(line_color_range.first, 200);
-  EXPECT_EQ(line_color_range.second, 400);
-}
-
-TEST(generic, test_enum_range_size) {
-  EXPECT_EQ(rfl::get_enumerator_array<InnerColor>().size(), 4);
-  EXPECT_EQ(rfl::get_enumerator_array<LineColor>().size(), 3);
-}
-
-TEST(generic, test_enum_range_write_and_read) {
-  const auto circle = Circle{.radius = 2.0,
-                             .inner_color = InnerColor::none,
-                             .line_color = LineColor::yellow};
+TEST(generic, test_enum_range) {
+  auto circle = Circle{.radius = 2.0,
+                       .inner_color = InnerColor::none,
+                       .line_color = LineColor::yellow};
 
   write_and_read(circle);
 }

--- a/tests/generic/test_enum_range.cpp
+++ b/tests/generic/test_enum_range.cpp
@@ -1,0 +1,57 @@
+#include <cassert>
+#include <iostream>
+// Redefine the range of the enums
+#define RFL_ENUM_RANGE_MIN -128
+#define RFL_ENUM_RANGE_MAX 128
+#include <rfl.hpp>
+#include <string>
+#include <vector>
+
+#include "write_and_read.hpp"
+
+namespace test_enum_range {
+
+enum class InnerColor { none = -128, red = -50, green = 0, blue = 128 };
+enum class LineColor { yellow = 200, purple = 300, orange = 400 };
+
+struct Circle {
+  float radius;
+  InnerColor inner_color;
+  LineColor line_color;
+};
+
+}  // namespace test_enum_range
+
+// Define the range of the LineColor enum
+template <>
+struct rfl::config::enum_range<test_enum_range::LineColor> {
+  static constexpr int min = 200;
+  static constexpr int max = 400;
+};
+
+namespace test_enum_range {
+
+TEST(generic, test_enum_range_get_min_max) {
+  auto inner_color_range = rfl::get_enum_range<InnerColor>();
+  EXPECT_EQ(inner_color_range.first, RFL_ENUM_RANGE_MIN);
+  EXPECT_EQ(inner_color_range.second, RFL_ENUM_RANGE_MAX);
+
+  auto line_color_range = rfl::get_enum_range<LineColor>();
+  EXPECT_EQ(line_color_range.first, 200);
+  EXPECT_EQ(line_color_range.second, 400);
+}
+
+TEST(generic, test_enum_range_size) {
+  EXPECT_EQ(rfl::get_enumerator_array<InnerColor>().size(), 4);
+  EXPECT_EQ(rfl::get_enumerator_array<LineColor>().size(), 3);
+}
+
+TEST(generic, test_enum_range_write_and_read) {
+  const auto circle = Circle{.radius = 2.0,
+                             .inner_color = InnerColor::none,
+                             .line_color = LineColor::yellow};
+
+  write_and_read(circle);
+}
+
+}  // namespace test_enum_range

--- a/tests/generic/test_enum_range_min_max.cpp
+++ b/tests/generic/test_enum_range_min_max.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+// Redefine the range of the enums
+#define RFL_ENUM_RANGE_MIN -128
+#define RFL_ENUM_RANGE_MAX 128
+#include <rfl.hpp>
+
+namespace test_enum_range_min_max {
+
+enum class InnerColor { none = -128, red = -50, green = 0, blue = 128 };
+enum class LineColor { yellow = 200, purple = 300, orange = 400 };
+
+}  // namespace test_enum_range_min_max
+
+// Define the range of the LineColor enum
+template <>
+struct rfl::config::enum_range<test_enum_range_min_max::LineColor> {
+  static constexpr int min = 200;
+  static constexpr int max = 400;
+};
+
+namespace test_enum_range_min_max {
+
+TEST(generic, test_enum_range_min_max) {
+  auto [inner_min, inner_max] = rfl::get_enum_range<InnerColor>();
+  EXPECT_EQ(inner_min, RFL_ENUM_RANGE_MIN);
+  EXPECT_EQ(inner_max, RFL_ENUM_RANGE_MAX);
+
+  auto [line_min, line_max] = rfl::get_enum_range<LineColor>();
+  EXPECT_EQ(line_min, 200);
+  EXPECT_EQ(line_max, 400);
+}
+
+}  // namespace test_enum_range_min_max

--- a/tests/generic/test_enum_range_size.cpp
+++ b/tests/generic/test_enum_range_size.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+// Redefine the range of the enums
+#define RFL_ENUM_RANGE_MIN -128
+#define RFL_ENUM_RANGE_MAX 128
+#include <rfl.hpp>
+
+namespace test_enum_range_size {
+
+enum class InnerColor { none = -128, red = -50, green = 0, blue = 128 };
+enum class LineColor { yellow = 200, purple = 300, orange = 400 };
+
+}  // namespace test_enum_range_size
+
+// Define the range of the LineColor enum
+template <>
+struct rfl::config::enum_range<test_enum_range_size::LineColor> {
+  static constexpr int min = 200;
+  static constexpr int max = 400;
+};
+
+namespace test_enum_range_size {
+
+TEST(generic, test_enum_range_size) {
+  EXPECT_EQ(rfl::get_enumerator_array<InnerColor>().size(), 4);
+  EXPECT_EQ(rfl::get_enumerator_array<LineColor>().size(), 3);
+}
+
+}  // namespace test_enum_range_size

--- a/tests/generic/test_enum_range_size.cpp
+++ b/tests/generic/test_enum_range_size.cpp
@@ -8,14 +8,22 @@ namespace test_enum_range_size {
 
 enum class InnerColor { none = -128, red = -50, green = 0, blue = 128 };
 enum class LineColor { yellow = 200, purple = 300, orange = 400 };
+enum class OneColor {black};
 
 }  // namespace test_enum_range_size
 
 // Define the range of the LineColor enum
 template <>
 struct rfl::config::enum_range<test_enum_range_size::LineColor> {
-  static constexpr int min = 200;
+  static constexpr int min = 0;
   static constexpr int max = 400;
+};
+
+// Define the range of the OneColor enum
+template <>
+struct rfl::config::enum_range<test_enum_range_size::OneColor> {
+  static constexpr int min = 0;
+  static constexpr int max = 0;
 };
 
 namespace test_enum_range_size {
@@ -23,6 +31,7 @@ namespace test_enum_range_size {
 TEST(generic, test_enum_range_size) {
   EXPECT_EQ(rfl::get_enumerator_array<InnerColor>().size(), 4);
   EXPECT_EQ(rfl::get_enumerator_array<LineColor>().size(), 3);
+  EXPECT_EQ(rfl::get_enumerator_array<OneColor>().size(), 1);
 }
 
 }  // namespace test_enum_range_size


### PR DESCRIPTION
Currently, the supported value range in reflect-cpp is 0 to 127. This change aims to allow users to customize the enum range.

Enum values must be in the range `[RFT_ENUM_RANGE_MIN, RFT_ENUM_RANGE_MAX]`. If the range is not specified, the
   default range is `[0, 127]`.

- You can specify a custom range for the all enum values by defining `RFT_ENUM_RANGE_MIN` and `RFT_ENUM_RANGE_MAX`
      before including the reflect-cpp header:

        #define RFL_ENUM_RANGE_MIN -128
        #define RFL_ENUM_RANGE_MAX 128
        #include <rfl.hpp>

- You can specify a custom range for a specific enum by defining the specialization `rfl::config::enum_range` for
      the enum type :

      enum class Color { yellow = 200, purple = 300, orange = 400 };
   
      template <>
      struct rfl::config::enum_range<Color> {
        static constexpr int min = 200;
        static constexpr int max = 400;
      };
