### PR TITLE
fix bytestring being serialized as vector of flag enums

### DIFF
--- a/include/rfl/Bytestring.hpp
+++ b/include/rfl/Bytestring.hpp
@@ -5,8 +5,13 @@
 #include <vector>
 
 namespace rfl {
-
-using Bytestring = std::vector<std::byte>;
+// custom type to avoid serializing this as a vector of enums
+// in other means this is the same as
+// using Bytestring = std::vector<std::byte>;
+class Bytestring : public std::vector<std::byte> {
+public:
+  using std::vector<std::byte>::vector;
+};
 
 }  // namespace rfl
 

--- a/include/rfl/avro/Reader.hpp
+++ b/include/rfl/avro/Reader.hpp
@@ -76,7 +76,7 @@ struct Reader {
         return error("Could not cast to bytestring.");
       }
       const auto data = internal::ptr_cast<const std::byte*>(ptr);
-      return rfl::Bytestring(data, data + size - 1);
+      return rfl::Bytestring(data, data + size);
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       if (type != AVRO_BOOLEAN) {
         return rfl::error("Could not cast to boolean.");

--- a/include/rfl/avro/Writer.hpp
+++ b/include/rfl/avro/Writer.hpp
@@ -188,7 +188,7 @@ class Writer {
     } else if constexpr (std::is_same<std::remove_cvref_t<T>,
                                       rfl::Bytestring>()) {
       auto var = _var;
-      avro_value_set_bytes(_val, var.data(), var.size() + 1);
+      avro_value_set_bytes(_val, var.data(), var.size());
 
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       avro_value_set_boolean(_val, _var);

--- a/include/rfl/bson/Writer.hpp
+++ b/include/rfl/bson/Writer.hpp
@@ -104,7 +104,7 @@ class Writer {
                                       rfl::Bytestring>()) {
       bson_array_builder_append_binary(
           _parent->val_, BSON_SUBTYPE_BINARY,
-          internal::ptr_cast<const uint8_t*>(_var.c_str()),
+          internal::ptr_cast<const uint8_t*>(_var.data()),
           static_cast<uint32_t>(_var.size()));
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       bson_array_builder_append_bool(_parent->val_, _var);
@@ -134,7 +134,7 @@ class Writer {
                                       rfl::Bytestring>()) {
       bson_append_binary(_parent->val_, _name.data(),
                          static_cast<int>(_name.size()), BSON_SUBTYPE_BINARY,
-                         internal::ptr_cast<const uint8_t*>(_var.c_str()),
+                         internal::ptr_cast<const uint8_t*>(_var.data()),
                          static_cast<uint32_t>(_var.size()));
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       bson_append_bool(_parent->val_, _name.data(),

--- a/include/rfl/flexbuf/Writer.hpp
+++ b/include/rfl/flexbuf/Writer.hpp
@@ -97,7 +97,7 @@ struct Writer {
       fbb_->String(_name.data(), _var);
     } else if constexpr (std::is_same<std::remove_cvref_t<T>,
                                       rfl::Bytestring>()) {
-      fbb_->Blob(_name.data(), _var.c_str(), _var.size());
+      fbb_->Blob(_name.data(), _var.data(), _var.size());
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       fbb_->Bool(_name.data(), _var);
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
@@ -116,7 +116,7 @@ struct Writer {
       fbb_->String(_var);
     } else if constexpr (std::is_same<std::remove_cvref_t<T>,
                                       rfl::Bytestring>()) {
-      fbb_->Blob(_var.c_str(), _var.size());
+      fbb_->Blob(_var.data(), _var.size());
     } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>()) {
       fbb_->Bool(_var);
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {

--- a/include/rfl/internal/enums/StringConverter.hpp
+++ b/include/rfl/internal/enums/StringConverter.hpp
@@ -36,6 +36,9 @@ class StringConverter {
 
   /// Transforms a string to the matching enum.
   static Result<EnumType> string_to_enum(const std::string& _str) {
+    static_assert(names_.size != 0,
+                  "No enum could be identified. Please choose enum values "
+                  "between 0 to 127 or for flag enums choose 1,2,4,8,16,...");
     if constexpr (is_flag_enum_) {
       return string_to_flag_enum(_str);
     } else {

--- a/include/rfl/msgpack/Writer.hpp
+++ b/include/rfl/msgpack/Writer.hpp
@@ -99,7 +99,7 @@ class Writer {
       msgpack_pack_str_body(pk_, _var.c_str(), _var.size());
     } else if constexpr (std::is_same<Type, rfl::Bytestring>()) {
       msgpack_pack_bin(pk_, _var.size());
-      msgpack_pack_bin_body(pk_, _var.c_str(), _var.size());
+      msgpack_pack_bin_body(pk_, _var.data(), _var.size());
     } else if constexpr (std::is_same<Type, bool>()) {
       if (_var) {
         msgpack_pack_true(pk_);


### PR DESCRIPTION
This is a fix for the regression introduced with the Bytestring std::vector replacement.
It was serialized as a vector of enums instead of binary data.
I haven't found a cleaner way other than making a fake type to avoid it being treated as `std::vector<T>`.
Also, I can make write_and_read return serialized size, so that such regression can be caught by the test_bytestring and explicit size check in it