### PR TITLE
Test for JSON & CBOR encoding error handling

### DIFF
--- a/include/rfl/cbor/read.hpp
+++ b/include/rfl/cbor/read.hpp
@@ -20,17 +20,31 @@ using InputVarType = typename Reader::InputVarType;
 /// Parses an object from CBOR using reflection.
 template <class T, class... Ps>
 Result<internal::wrap_in_rfl_array_t<T>> read(const std::vector<char>& _bytes) {
-  auto val = jsoncons::cbor::decode_cbor<jsoncons::json>(_bytes);
-  auto r = Reader();
-  return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  // TODO: Use a non-throwing decode_cbor(), pending https://github.com/danielaparker/jsoncons/issues/615
+  try {
+    auto val = jsoncons::cbor::decode_cbor<jsoncons::json>(_bytes);
+    auto r = Reader();
+    return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  } catch(const jsoncons::ser_error& e)  {
+    std::string error("Could not parse CBOR: ");
+    error.append(e.what());
+    return rfl::error(error);
+  }
 }
 
 /// Parses an object from a stream.
 template <class T, class... Ps>
 Result<internal::wrap_in_rfl_array_t<T>> read(std::istream& _stream) {
-  auto val = jsoncons::cbor::decode_cbor<jsoncons::json>(_stream);
-  auto r = Reader();
-  return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  // TODO: Use a non-throwing decode_cbor(), pending https://github.com/danielaparker/jsoncons/issues/615
+  try {
+    auto val = jsoncons::cbor::decode_cbor<jsoncons::json>(_stream);
+    auto r = Reader();
+    return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  } catch(const jsoncons::ser_error& e)  {
+    std::string error("Could not parse CBOR: ");
+    error.append(e.what());
+    return rfl::error(error);
+  }
 }
 
 }  // namespace rfl::cbor

--- a/include/rfl/ubjson/read.hpp
+++ b/include/rfl/ubjson/read.hpp
@@ -20,17 +20,31 @@ using InputVarType = typename Reader::InputVarType;
 /// Parses an object from UBJSON using reflection.
 template <class T, class... Ps>
 Result<internal::wrap_in_rfl_array_t<T>> read(const std::vector<char>& _bytes) {
-  auto val = jsoncons::ubjson::decode_ubjson<jsoncons::json>(_bytes);
-  auto r = Reader();
-  return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  // TODO: Use a non-throwing decode_ubjson(), pending https://github.com/danielaparker/jsoncons/issues/615
+  try {
+    auto val = jsoncons::ubjson::decode_ubjson<jsoncons::json>(_bytes);
+    auto r = Reader();
+    return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  } catch(const jsoncons::ser_error& e)  {
+    std::string error("Could not parse UBJSON: ");
+    error.append(e.what());
+    return rfl::error(error);
+  }
 }
 
 /// Parses an object from a stream.
 template <class T, class... Ps>
 Result<internal::wrap_in_rfl_array_t<T>> read(std::istream& _stream) {
-  auto val = jsoncons::ubjson::decode_ubjson<jsoncons::json>(_stream);
-  auto r = Reader();
-  return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  // TODO: Use a non-throwing decode_ubjson(), pending https://github.com/danielaparker/jsoncons/issues/615
+  try {
+    auto val = jsoncons::ubjson::decode_ubjson<jsoncons::json>(_stream);
+    auto r = Reader();
+    return Parser<T, Processors<Ps...>>::read(r, InputVarType{&val});
+  } catch(const jsoncons::ser_error& e)  {
+    std::string error("Could not parse UBJSON: ");
+    error.append(e.what());
+    return rfl::error(error);
+  }
 }
 
 }  // namespace rfl::ubjson

--- a/tests/cbor/test_error_messages.cpp
+++ b/tests/cbor/test_error_messages.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <rfl.hpp>
+#include <rfl/cbor.hpp>
+#include <rfl/json.hpp>
+#include <string>
+#include <vector>
+
+namespace test_error_messages {
+
+struct Person {
+  rfl::Rename<"firstName", std::string> first_name;
+  rfl::Rename<"lastName", std::string> last_name;
+  rfl::Timestamp<"%Y-%m-%d"> birthday;
+  std::vector<Person> children;
+};
+
+TEST(cbor, test_field_error_messages) {
+  const std::string faulty_string =
+      R"({"firstName":"Homer","lastName":12345,"birthday":"04/19/1987"})";
+  const auto faulty_generic = rfl::json::read<rfl::Generic>(faulty_string);
+  const auto faulty_cbor = rfl::cbor::write(faulty_generic);
+  const auto result = rfl::cbor::read<Person>(faulty_cbor);
+
+  // Order of errors is different than input JSON because rfl::Generic doesn't preserve order
+  const std::string expected = R"(Found 3 errors:
+1) Failed to parse field 'birthday': String '04/19/1987' did not match format '%Y-%m-%d'.
+2) Failed to parse field 'lastName': Could not cast to string.
+3) Field named 'children' not found.)";
+
+  EXPECT_TRUE(!result.has_value() && true);
+
+  EXPECT_EQ(result.error().what(), expected);
+}
+
+TEST(cbor, test_decode_error_causes_exception) {
+  const std::string good_string =
+      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
+  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
+  auto faulty_cbor = rfl::cbor::write(good_generic);
+  faulty_cbor[1] = '\xff';  // Corrupt structure of CBOR encoding
+
+  rfl::Result<Person> result = rfl::error("result didn't get set");
+  EXPECT_THROW({
+    try
+    {
+      result = rfl::cbor::read<Person>(faulty_cbor);
+    }
+    catch( const jsoncons::ser_error& e )
+    {
+      // and this tests that it has the correct message
+      const std::string expected = R"(An unknown type was found in the stream at position 1)";
+      EXPECT_EQ( e.what(), expected );
+      throw;
+    }
+  }, jsoncons::ser_error );
+
+  const std::string expected = R"(result didn't get set)";
+  EXPECT_EQ(result.error().what(), expected);
+
+  EXPECT_TRUE(!result.has_value() && true);
+}
+
+TEST(cbor, test_decode_error_without_exception) {
+  GTEST_SKIP() << "Expected failing test represents future ideal behavior";
+  // This test is expected to fail because the error handling in the CBOR library
+  // doesn't return an error result, but rather throw exceptions. The test is
+  // written to demonstrate the desired behavior, but the actual implementation
+  // may not support this yet.
+  const std::string good_string =
+      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
+  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
+  auto faulty_cbor = rfl::cbor::write(good_generic);
+  faulty_cbor[1] = '\xff';  // Corrupt structure of CBOR encoding
+
+  rfl::Result<Person> result = rfl::error("result didn't get set");
+  EXPECT_NO_THROW({
+    result = rfl::cbor::read<Person>(faulty_cbor);
+  });
+
+  // A proposal: A generic prefix, followed by the underlying library's error output
+  const std::string expected = R"(Could not parse CBOR: An unknown type was found in the stream at position 1)";
+  EXPECT_EQ(result.error().what(), expected);
+
+  EXPECT_TRUE(!result.has_value() && true);
+}
+
+}  // namespace test_error_messages

--- a/tests/cbor/test_error_messages.cpp
+++ b/tests/cbor/test_error_messages.cpp
@@ -34,40 +34,7 @@ TEST(cbor, test_field_error_messages) {
   EXPECT_EQ(result.error().what(), expected);
 }
 
-TEST(cbor, test_decode_error_causes_exception) {
-  const std::string good_string =
-      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
-  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
-  auto faulty_cbor = rfl::cbor::write(good_generic);
-  faulty_cbor[1] = '\xff';  // Corrupt structure of CBOR encoding
-
-  rfl::Result<Person> result = rfl::error("result didn't get set");
-  EXPECT_THROW({
-    try
-    {
-      result = rfl::cbor::read<Person>(faulty_cbor);
-    }
-    catch( const jsoncons::ser_error& e )
-    {
-      // and this tests that it has the correct message
-      const std::string expected = R"(An unknown type was found in the stream at position 1)";
-      EXPECT_EQ( e.what(), expected );
-      throw;
-    }
-  }, jsoncons::ser_error );
-
-  const std::string expected = R"(result didn't get set)";
-  EXPECT_EQ(result.error().what(), expected);
-
-  EXPECT_TRUE(!result.has_value() && true);
-}
-
 TEST(cbor, test_decode_error_without_exception) {
-  GTEST_SKIP() << "Expected failing test represents future ideal behavior";
-  // This test is expected to fail because the error handling in the CBOR library
-  // doesn't return an error result, but rather throw exceptions. The test is
-  // written to demonstrate the desired behavior, but the actual implementation
-  // may not support this yet.
   const std::string good_string =
       R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
   const auto good_generic = rfl::json::read<rfl::Generic>(good_string);

--- a/tests/json/test_error_messages.cpp
+++ b/tests/json/test_error_messages.cpp
@@ -15,7 +15,7 @@ struct Person {
   std::vector<Person> children;
 };
 
-TEST(json, test_error_messages) {
+TEST(json, test_field_error_messages) {
   const std::string faulty_string =
       R"({"firstName":"Homer","lastName":12345,"birthday":"04/19/1987"})";
 
@@ -30,4 +30,20 @@ TEST(json, test_error_messages) {
 
   EXPECT_EQ(result.error().what(), expected);
 }
+
+TEST(json, test_decode_error_without_exception) {
+  // Note using valid field names, but invalid JSON delimiter ';'
+  const std::string faulty_string =
+      R"({"firstName":"Homer";"lastName":"Simpson";"birthday":"1987-04-19"})";
+
+  rfl::Result<Person> result = rfl::error("result didn't get set");
+  EXPECT_NO_THROW({
+    result = rfl::json::read<Person>(faulty_string);
+  });
+
+  EXPECT_TRUE(!result.has_value() && true);
+
+  EXPECT_EQ(result.error().what(), "Could not parse document");
+}
+
 }  // namespace test_error_messages

--- a/tests/ubjson/test_error_messages.cpp
+++ b/tests/ubjson/test_error_messages.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <rfl.hpp>
+#include <rfl/ubjson.hpp>
+#include <rfl/json.hpp>
+#include <string>
+#include <vector>
+
+namespace test_error_messages {
+
+struct Person {
+  rfl::Rename<"firstName", std::string> first_name;
+  rfl::Rename<"lastName", std::string> last_name;
+  rfl::Timestamp<"%Y-%m-%d"> birthday;
+  std::vector<Person> children;
+};
+
+TEST(ubjson, test_field_error_messages) {
+  const std::string faulty_string =
+      R"({"firstName":"Homer","lastName":12345,"birthday":"04/19/1987"})";
+  const auto faulty_generic = rfl::json::read<rfl::Generic>(faulty_string);
+  const auto faulty_ubjson = rfl::ubjson::write(faulty_generic);
+  const auto result = rfl::ubjson::read<Person>(faulty_ubjson);
+
+  // Order of errors is different than input JSON because rfl::Generic doesn't preserve order
+  const std::string expected = R"(Found 3 errors:
+1) Failed to parse field 'birthday': String '04/19/1987' did not match format '%Y-%m-%d'.
+2) Failed to parse field 'lastName': Could not cast to string.
+3) Field named 'children' not found.)";
+
+  EXPECT_TRUE(!result.has_value() && true);
+
+  EXPECT_EQ(result.error().what(), expected);
+}
+
+TEST(ubjson, test_decode_error_causes_exception) {
+  const std::string good_string =
+      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
+  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
+  auto faulty_ubjson = rfl::ubjson::write(good_generic);
+  faulty_ubjson[0] = '\xff';  // Corrupt structure of ubjson encoding
+
+  rfl::Result<Person> result = rfl::error("result didn't get set");
+  EXPECT_THROW({
+    try
+    {
+      result = rfl::ubjson::read<Person>(faulty_ubjson);
+    }
+    catch( const jsoncons::ser_error& e )
+    {
+      // and this tests that it has the correct message
+      const std::string expected = R"(Unknown type at position 1)";
+      EXPECT_EQ( e.what(), expected );
+      throw;
+    }
+  }, jsoncons::ser_error );
+
+  const std::string expected = R"(result didn't get set)";
+  EXPECT_EQ(result.error().what(), expected);
+
+  EXPECT_TRUE(!result.has_value() && true);
+}
+
+TEST(ubjson, test_decode_error_without_exception) {
+  GTEST_SKIP() << "Expected failing test represents future ideal behavior";
+  // This test is expected to fail because the error handling in the UBJSON library
+  // doesn't return an error result, but rather throw exceptions. The test is
+  // written to demonstrate the desired behavior, but the actual implementation
+  // may not support this yet.
+  const std::string good_string =
+      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
+  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
+  auto faulty_ubjson = rfl::ubjson::write(good_generic);
+  faulty_ubjson[0] = '\xff';  // Corrupt structure of ubjson encoding
+
+  rfl::Result<Person> result = rfl::error("result didn't get set");
+  EXPECT_NO_THROW({
+    result = rfl::ubjson::read<Person>(faulty_ubjson);
+  });
+
+  // A proposal: A generic prefix, followed by the underlying library's error output
+  const std::string expected = R"(Could not parse ubjson: Unknown type at position 1)";
+  EXPECT_EQ(result.error().what(), expected);
+
+  EXPECT_TRUE(!result.has_value() && true);
+}
+
+}  // namespace test_error_messages

--- a/tests/ubjson/test_error_messages.cpp
+++ b/tests/ubjson/test_error_messages.cpp
@@ -34,40 +34,7 @@ TEST(ubjson, test_field_error_messages) {
   EXPECT_EQ(result.error().what(), expected);
 }
 
-TEST(ubjson, test_decode_error_causes_exception) {
-  const std::string good_string =
-      R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
-  const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
-  auto faulty_ubjson = rfl::ubjson::write(good_generic);
-  faulty_ubjson[0] = '\xff';  // Corrupt structure of ubjson encoding
-
-  rfl::Result<Person> result = rfl::error("result didn't get set");
-  EXPECT_THROW({
-    try
-    {
-      result = rfl::ubjson::read<Person>(faulty_ubjson);
-    }
-    catch( const jsoncons::ser_error& e )
-    {
-      // and this tests that it has the correct message
-      const std::string expected = R"(Unknown type at position 1)";
-      EXPECT_EQ( e.what(), expected );
-      throw;
-    }
-  }, jsoncons::ser_error );
-
-  const std::string expected = R"(result didn't get set)";
-  EXPECT_EQ(result.error().what(), expected);
-
-  EXPECT_TRUE(!result.has_value() && true);
-}
-
 TEST(ubjson, test_decode_error_without_exception) {
-  GTEST_SKIP() << "Expected failing test represents future ideal behavior";
-  // This test is expected to fail because the error handling in the UBJSON library
-  // doesn't return an error result, but rather throw exceptions. The test is
-  // written to demonstrate the desired behavior, but the actual implementation
-  // may not support this yet.
   const std::string good_string =
       R"({"firstName":"Homer","lastName":"Simpson","birthday":"1987-04-19"})";
   const auto good_generic = rfl::json::read<rfl::Generic>(good_string);
@@ -80,7 +47,7 @@ TEST(ubjson, test_decode_error_without_exception) {
   });
 
   // A proposal: A generic prefix, followed by the underlying library's error output
-  const std::string expected = R"(Could not parse ubjson: Unknown type at position 1)";
+  const std::string expected = R"(Could not parse UBJSON: Unknown type at position 1)";
   EXPECT_EQ(result.error().what(), expected);
 
   EXPECT_TRUE(!result.has_value() && true);


### PR DESCRIPTION
This PR is a working illustration of the problem reported in #429.

The current implementation using `jsoncons::cbor::decode_cbor()` always throws when there is a fundamental CBOR decoding error, as opposed to a mere structure reflection mismatch.