### PR TITLE
Fix cbor encoding for uint64_t's

### DIFF
--- a/include/rfl/cbor/Writer.hpp
+++ b/include/rfl/cbor/Writer.hpp
@@ -103,6 +103,8 @@ class Writer {
       encoder_->bool_value(_var);
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       encoder_->double_value(static_cast<double>(_var));
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      encoder_->uint64_value(static_cast<std::uint64_t>(_var));
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
       encoder_->int64_value(static_cast<std::int64_t>(_var));
     } else {

--- a/tests/cbor/test_integers.cpp
+++ b/tests/cbor/test_integers.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include <rfl/cbor.hpp>
+
+namespace test_integers {
+
+TEST(cbor, test_integers_signedness) {
+
+    static constexpr uint64_t BIG_INT = 0xffffffffffffffff;
+
+    struct Unsigned {
+        uint64_t u64;
+    };
+
+    struct Signed {
+        int64_t i64;
+    };
+
+    std::vector<char> unsigned_buffer = rfl::cbor::write(Unsigned{BIG_INT});
+    std::vector<unsigned char> unsigned_expected = {
+        0xA1, 0x63, 0x75, 0x36, 0x34,
+        0x1B, // Per RFC 8949, Initial byte '0x1B' indicates "unsigned integer (eight-byte uint64_t follows)" 
+              // See: https://www.rfc-editor.org/rfc/rfc8949.html#section-appendix.b
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+    };
+
+    EXPECT_EQ(std::vector<char>(unsigned_expected.begin(), unsigned_expected.end()), unsigned_buffer);
+
+    std::vector<char> signed_buffer = rfl::cbor::write(Signed{static_cast<int64_t>(BIG_INT)});
+    std::vector<unsigned char> signed_expected = {
+        0xA1, 0x63, 0x69, 0x36, 0x34,
+        0x20  // Per RFC 8949, Initial byte '0x20' indicates "negative integer -1-0x00..-1-0x17 (-1..-24)" 
+              // See: https://www.rfc-editor.org/rfc/rfc8949.html#section-appendix.b
+    };
+
+    EXPECT_EQ(std::vector<char>(signed_expected.begin(), signed_expected.end()), signed_buffer);
+}
+
+}  // namespace test_integers


### PR DESCRIPTION
A fix for cbor encoding; unsigned integers were being emitted as signed ints.