### PR TITLE
rename _res to _result to avoid macro conflict

### DIFF
--- a/include/rfl/OneOf.hpp
+++ b/include/rfl/OneOf.hpp
@@ -43,7 +43,7 @@ struct OneOf {
   static rfl::Result<T> validate_impl(const T& _value,
                                       std::vector<Error> _errors) {
     return Head::validate(_value)
-        .and_then([&](auto&& _res) -> rfl::Result<T> {
+        .and_then([&](auto&& _result) -> rfl::Result<T> {
           if constexpr (sizeof...(Tail) == 0) {
             if (_errors.size() == sizeof...(Cs)) {
               return _value;

--- a/include/rfl/Variant.hpp
+++ b/include/rfl/Variant.hpp
@@ -283,103 +283,103 @@ class Variant {
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_result(F& _f, std::optional<ResultType>* _res,
+  void do_visit_with_result(F& _f, std::optional<ResultType>* _result,
                             std::integer_sequence<IndexType, _is...>) {
     auto visit_one = [this]<IndexType _i>(const F& _f,
-                                          std::optional<ResultType>* _res,
+                                          std::optional<ResultType>* _result,
                                           Index<_i>) {
-      if (!*_res && index_ == _i) {
-        _res->emplace(_f(get_alternative<_i>()));
+      if (!*_result && index_ == _i) {
+        _result->emplace(_f(get_alternative<_i>()));
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_result(F& _f, std::optional<ResultType>* _res,
+  void do_visit_with_result(F& _f, std::optional<ResultType>* _result,
                             std::integer_sequence<IndexType, _is...>) const {
     auto visit_one = [this]<IndexType _i>(const F& _f,
-                                          std::optional<ResultType>* _res,
+                                          std::optional<ResultType>* _result,
                                           Index<_i>) {
-      if (!*_res && index_ == _i) {
-        _res->emplace(_f(get_alternative<_i>()));
+      if (!*_result && index_ == _i) {
+        _result->emplace(_f(get_alternative<_i>()));
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_result(const F& _f, std::optional<ResultType>* _res,
+  void do_visit_with_result(const F& _f, std::optional<ResultType>* _result,
                             std::integer_sequence<IndexType, _is...>) {
     const auto visit_one = [this]<IndexType _i>(const F& _f,
-                                                std::optional<ResultType>* _res,
+                                                std::optional<ResultType>* _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        _res->emplace(_f(get_alternative<_i>()));
+      if (!*_result && index_ == _i) {
+        _result->emplace(_f(get_alternative<_i>()));
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_result(const F& _f, std::optional<ResultType>* _res,
+  void do_visit_with_result(const F& _f, std::optional<ResultType>* _result,
                             std::integer_sequence<IndexType, _is...>) const {
     const auto visit_one = [this]<IndexType _i>(const F& _f,
-                                                std::optional<ResultType>* _res,
+                                                std::optional<ResultType>* _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        _res->emplace(_f(get_alternative<_i>()));
+      if (!*_result && index_ == _i) {
+        _result->emplace(_f(get_alternative<_i>()));
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_reference(F& _f, ResultType** _res,
+  void do_visit_with_reference(F& _f, ResultType** _result,
                                std::integer_sequence<IndexType, _is...>) {
-    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _res,
+    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        *_res = &_f(get_alternative<_i>());
+      if (!*_result && index_ == _i) {
+        *_result = &_f(get_alternative<_i>());
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_reference(F& _f, ResultType** _res,
+  void do_visit_with_reference(F& _f, ResultType** _result,
                                std::integer_sequence<IndexType, _is...>) const {
-    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _res,
+    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        *_res = &_f(get_alternative<_i>());
+      if (!*_result && index_ == _i) {
+        *_result = &_f(get_alternative<_i>());
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_reference(const F& _f, ResultType** _res,
+  void do_visit_with_reference(const F& _f, ResultType** _result,
                                std::integer_sequence<IndexType, _is...>) {
-    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _res,
+    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        *_res = &_f(get_alternative<_i>());
+      if (!*_result && index_ == _i) {
+        *_result = &_f(get_alternative<_i>());
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <class F, class ResultType, IndexType... _is>
-  void do_visit_with_reference(const F& _f, ResultType** _res,
+  void do_visit_with_reference(const F& _f, ResultType** _result,
                                std::integer_sequence<IndexType, _is...>) const {
-    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _res,
+    const auto visit_one = [this]<IndexType _i>(const F& _f, ResultType** _result,
                                                 Index<_i>) {
-      if (!*_res && index_ == _i) {
-        *_res = &_f(get_alternative<_i>());
+      if (!*_result && index_ == _i) {
+        *_result = &_f(get_alternative<_i>());
       }
     };
-    (visit_one(_f, _res, Index<_is>{}), ...);
+    (visit_one(_f, _result, Index<_is>{}), ...);
   }
 
   template <IndexType _i>

--- a/include/rfl/parsing/Parser_tagged_union.hpp
+++ b/include/rfl/parsing/Parser_tagged_union.hpp
@@ -125,7 +125,7 @@ struct Parser<R, W, TaggedUnion<_discriminator, AlternativeTypes...>,
   static void set_if_disc_value_matches(const R& _r,
                                         const std::string& _disc_value,
                                         const InputVarType& _var,
-                                        ResultType* _res,
+                                        ResultType* _result,
                                         bool* _match_found) noexcept {
     using AlternativeType = std::remove_cvref_t<
         std::variant_alternative_t<_i, std::variant<AlternativeTypes...>>>;
@@ -156,12 +156,12 @@ struct Parser<R, W, TaggedUnion<_discriminator, AlternativeTypes...>,
       if constexpr (no_field_names_) {
         using T = tagged_union_wrapper_no_ptr_t<std::invoke_result_t<
             decltype(wrap_if_necessary<AlternativeType>), AlternativeType>>;
-        *_res = Parser<R, W, T, ProcessorsType>::read(_r, _var)
+        *_result = Parser<R, W, T, ProcessorsType>::read(_r, _var)
                     .transform(get_fields)
                     .transform(to_tagged_union)
                     .transform_error(embellish_error);
       } else {
-        *_res = Parser<R, W, AlternativeType, ProcessorsType>::read(_r, _var)
+        *_result = Parser<R, W, AlternativeType, ProcessorsType>::read(_r, _var)
                     .transform(to_tagged_union)
                     .transform_error(embellish_error);
       }


### PR DESCRIPTION
I met a macro confilict.

It's in `resolv.h` in linux. In which there is a macro called `_res`.

So I renamed  _res to _result to avoid macro conflict.

BTW, just curious, why do you name all variables with a prefix underline? These names are likely to be used in system headers.