### PR TITLE
make sure reflectcpp library namespace is also available when not installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ else()
     add_library(reflectcpp STATIC)
 endif()
 
+add_library(reflectcpp::reflectcpp ALIAS reflectcpp)
+
 if (MSVC)
     target_compile_options(reflectcpp PRIVATE $<$<CONFIG:Debug>:-Wall>)
 else()


### PR DESCRIPTION
What is the problem ?

When using reflect-cpp without installing it, the CMake target reflectcpp::reflectcpp is not automatically provided. This namespaced target is only made available through installation.

Abstract Example:
```
if(MY_LIB_BUILD_DEPS)
    FetchContent_Declare(
        reflectcpp
        GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
        GIT_TAG 2a0fdeabe35bdab0e07e05d4f869ca88bd6d2b8c
        OVERRIDE_FIND_PACKAGE
    )
    // Here we get just reflectcpp
    FetchContent_MakeAvailable(reflectcpp)

     // Manually create an alias to have a common interface
    add_library(reflectcpp::reflectcpp ALIAS reflectcpp)
else()
     // Here we get the relfectcpp::reflectcpp target 
    find_package(reflectcpp REQUIRED)
endif()

...

target_link_libraries(${PROJECT_NAME} PRIVATE reflectcpp::reflectcpp)
```

What does this solve ?

This setup allows consistent usage of reflectcpp::reflectcpp whether reflect-cpp is:
1. Built from source (FetchContent or add_subdirectory)
2. Used as a pre-installed library (via find_package)


