### PR TITLE
Fix bug reading with 'tagged' variants when a variant is non-copyable

### DIFF
--- a/include/rfl/parsing/Parser_rfl_variant.hpp
+++ b/include/rfl/parsing/Parser_rfl_variant.hpp
@@ -57,7 +57,7 @@ class Parser<R, W, rfl::Variant<AlternativeTypes...>, ProcessorsType> {
       using FieldVariantType =
           rfl::Variant<VariantAlternativeWrapper<AlternativeTypes>...>;
       const auto from_field_variant =
-          [](const auto& _field) -> rfl::Variant<AlternativeTypes...> {
+          [](auto&& _field) -> rfl::Variant<AlternativeTypes...> {
         return std::move(_field.value());
       };
       return Parser<R, W, FieldVariantType, ProcessorsType>::read(_r, _var)

--- a/tests/json/test_add_tag_to_rfl_variant.cpp
+++ b/tests/json/test_add_tag_to_rfl_variant.cpp
@@ -12,7 +12,10 @@ namespace test_add_tag_to_rfl_variant {
 
 struct button_pressed_t {};
 
-struct button_released_t {};
+// Test that we can still use structs that must be moved
+struct button_released_t {
+  rfl::Box<int> button;
+};
 
 struct key_pressed_t {
   using Tag = rfl::Literal<"key_pressed">;
@@ -23,11 +26,14 @@ using my_event_type_t =
     rfl::Variant<button_pressed_t, button_released_t, key_pressed_t, int>;
 
 TEST(json, test_add_tag_to_rfl_variant) {
-  const auto vec = std::vector<my_event_type_t>(
-      {button_pressed_t{}, button_released_t{}, key_pressed_t{'c'}, 3});
+  std::vector<my_event_type_t> vec;
+  vec.emplace_back(button_pressed_t{});
+  vec.emplace_back(button_released_t{rfl::make_box<int>(4)});
+  vec.emplace_back(key_pressed_t{'c'});
+  vec.emplace_back(3);
 
   write_and_read<rfl::AddTagsToVariants>(
       vec,
-      R"([{"button_pressed_t":{}},{"button_released_t":{}},{"key_pressed":{"key":99}},{"int":3}])");
+      R"([{"button_pressed_t":{}},{"button_released_t":{"button":4}},{"key_pressed":{"key":99}},{"int":3}])");
 }
 }  // namespace test_add_tag_to_rfl_variant


### PR DESCRIPTION
Added a test. Needed to change the test to emplace each element rather than initializer_list due to the non-copyable element.