### PR TITLE
Add interfaces for jwt-cpp compatibility

### DIFF
--- a/include/rfl/Object.hpp
+++ b/include/rfl/Object.hpp
@@ -90,6 +90,8 @@ class Object {
   /// The number of elements currently inside the object.
   auto size() const { return data_.size(); }
 
+  std::size_t count(const key_type& key) const noexcept { return find(key) == size() ? 0 : 1; }
+
   /// The maximum possible size.
   auto max_size() const { return data_.max_size(); }
 

--- a/include/rfl/Object.hpp
+++ b/include/rfl/Object.hpp
@@ -90,7 +90,7 @@ class Object {
   /// The number of elements currently inside the object.
   auto size() const { return data_.size(); }
 
-  std::size_t count(const key_type& key) const noexcept { return find(key) == size() ? 0 : 1; }
+  std::size_t count(const key_type& key) const { return std::count_if(cbegin(), cend(), [&](const auto& p) { return p.first == key; }); }
 
   /// The maximum possible size.
   auto max_size() const { return data_.max_size(); }


### PR DESCRIPTION
I want to extend the [jwt-cpp library](https://github.com/Thalhammer/jwt-cpp) so it has reflect-cpp compatibility. The interfaces exposed by reflect-cpp are already almost compatible with the traits expected by jwt-cpp, but a small addition to rfl::Object is needed so that it exposes a `std::size_t count(const key_type& key) const` method. This PR adds that methd.