### PR TITLE
Better forwarding to improve read performance a little

### DIFF
--- a/include/rfl/Result.hpp
+++ b/include/rfl/Result.hpp
@@ -21,10 +21,13 @@ namespace rfl {
 class Error {
  public:
   Error(const std::string& _what) : what_(_what) {}
+  Error(std::string&& _what) : what_(std::move(_what)) {}
 
   Error(const Error& e) = default;
+  Error(Error&& e) = default;
 
   Error& operator=(const Error&) = default;
+  Error& operator=(Error&&) = default;
 
   /// Returns the error message, equivalent to .what() in std::exception.
   const std::string& what() const { return what_; }
@@ -429,6 +432,10 @@ class Result {
 /// Shorthand for unexpected error.
 inline Unexpected<Error> error(const std::string& _what) {
   return Unexpected<Error>(Error(_what));
+}
+
+inline Unexpected<Error> error(std::string&& _what) {
+  return Unexpected<Error>(Error(std::move(_what)));
 }
 
 /// Shorthand for unexpected error.

--- a/include/rfl/parsing/NamedTupleParser.hpp
+++ b/include/rfl/parsing/NamedTupleParser.hpp
@@ -305,14 +305,16 @@ struct NamedTupleParser {
     set.fill(false);
     std::vector<Error> errors;
     const auto reader = ViewReaderType(&_r, _view, &found, &set, &errors);
-    std::optional<Error> err;
     if constexpr (_no_field_names) {
-      err = _r.read_array(reader, _obj_or_arr);
+      const auto err = _r.read_array(reader, _obj_or_arr);
+      if (err) {
+        return std::make_pair(set, err);
+      }
     } else {
-      err = _r.read_object(reader, _obj_or_arr);
-    }
-    if (err) {
-      return std::make_pair(set, err);
+      const auto err = _r.read_object(reader, _obj_or_arr);
+      if (err) {
+        return std::make_pair(set, err);
+      }
     }
     handle_missing_fields(found, *_view, &set, &errors,
                           std::make_integer_sequence<int, size_>());
@@ -327,14 +329,16 @@ struct NamedTupleParser {
       NamedTupleType* _view) noexcept {
     std::vector<Error> errors;
     const auto reader = ViewReaderWithDefaultType(&_r, _view, &errors);
-    std::optional<Error> err;
     if constexpr (_no_field_names) {
-      err = _r.read_array(reader, _obj_or_arr);
+      const auto err = _r.read_array(reader, _obj_or_arr);
+      if (err) {
+        return err;
+      }
     } else {
-      err = _r.read_object(reader, _obj_or_arr);
-    }
-    if (err) {
-      return err;
+      const auto err = _r.read_object(reader, _obj_or_arr);
+      if (err) {
+        return err;
+      }
     }
     if (errors.size() != 0) {
       return to_single_error_message(errors);

--- a/include/rfl/parsing/Parser_default.hpp
+++ b/include/rfl/parsing/Parser_default.hpp
@@ -46,9 +46,10 @@ struct Parser {
   /// Expresses the variables as type T.
   static Result<T> read(const R& _r, const InputVarType& _var) noexcept {
     if constexpr (internal::has_read_reflector<T>) {
-      const auto wrap_in_t = [](auto _named_tuple) -> Result<T> {
+      const auto wrap_in_t = [](auto&& _named_tuple) -> Result<T> {
         try {
-          return Reflector<T>::to(_named_tuple);
+          using NT = decltype(_named_tuple);
+          return Reflector<T>::to(std::forward<NT>(_named_tuple));
         } catch (std::exception& e) {
           return error(e.what());
         }
@@ -67,9 +68,10 @@ struct Parser {
     } else {
       if constexpr (internal::has_reflection_type_v<T>) {
         using ReflectionType = std::remove_cvref_t<typename T::ReflectionType>;
-        const auto wrap_in_t = [](auto _named_tuple) -> Result<T> {
+        const auto wrap_in_t = [](auto&& _named_tuple) -> Result<T> {
           try {
-            return T{std::move(_named_tuple)};
+            using NT = decltype(_named_tuple);
+            return T{std::forward<NT>(_named_tuple)};
           } catch (std::exception& e) {
             return error(e.what());
           }

--- a/include/rfl/parsing/Parser_rfl_variant.hpp
+++ b/include/rfl/parsing/Parser_rfl_variant.hpp
@@ -68,6 +68,7 @@ class Parser<R, W, rfl::Variant<AlternativeTypes...>, ProcessorsType> {
     } else {
       std::optional<rfl::Variant<AlternativeTypes...>> result;
       std::vector<Error> errors;
+      errors.reserve(sizeof...(AlternativeTypes));
       read_variant(
           _r, _var, &result, &errors,
           std::make_integer_sequence<int, sizeof...(AlternativeTypes)>());
@@ -187,7 +188,7 @@ class Parser<R, W, rfl::Variant<AlternativeTypes...>, ProcessorsType> {
       if (res) {
         *_result = std::move(*res);
       } else {
-        _errors->emplace_back(res.error());
+        _errors->emplace_back(std::move(res.error()));
       }
     }
   }

--- a/include/rfl/parsing/Parser_variant.hpp
+++ b/include/rfl/parsing/Parser_variant.hpp
@@ -85,6 +85,7 @@ class Parser<R, W, std::variant<AlternativeTypes...>, ProcessorsType> {
     } else {
       std::optional<std::variant<AlternativeTypes...>> result;
       std::vector<Error> errors;
+      errors.reserve(sizeof...(AlternativeTypes));
       read_variant(
           _r, _var, &result, &errors,
           std::make_integer_sequence<int, sizeof...(AlternativeTypes)>());
@@ -215,7 +216,7 @@ class Parser<R, W, std::variant<AlternativeTypes...>, ProcessorsType> {
       if (res) {
         *_result = std::move(*res);
       } else {
-        _errors->emplace_back(res.error());
+        _errors->emplace_back(std::move(res.error()));
       }
     }
   }


### PR DESCRIPTION
Hello!

This isn't really a significant change, but it helps speed up `rfl::json::read<rfl::Generic>` almost twice in the release build (at least in the benchmarked case).

Sorry for not using your benchmark suite here, I had problems getting the `vcpkg` dependencies properly compiled with GCC15 that ships with my system.

I also tried to look into improving the debug build performance of `rfl::to_generic`, but couldn't find anything to improve there, at least not as simple.

## Benchmark results (on my PC, Ryzen 3600)

### In release mode

Before:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
read_struct               95.5 ns         94.4 ns      7332806
read_generic               645 ns          637 ns      1117257
write_struct               104 ns          103 ns      6884743
write_generic              144 ns          142 ns      4990100
to_generic                 115 ns          114 ns      6160175
to_generic_via_json        774 ns          765 ns       932490
```

After:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
read_struct               94.9 ns         93.7 ns      7444236
read_generic               367 ns          363 ns      1945679
write_struct               104 ns          103 ns      6845176
write_generic              132 ns          130 ns      5413376
to_generic                 119 ns          118 ns      5871778
to_generic_via_json        497 ns          491 ns      1442071
```

### In debug mode

Before:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
read_struct               1461 ns         1445 ns       493132
read_generic              9450 ns         9337 ns        74690
write_struct               657 ns          649 ns      1092616
write_generic             1083 ns         1072 ns       646018
to_generic                3980 ns         3937 ns       175912
to_generic_via_json      10213 ns        10119 ns        69557
```

After:
```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
read_struct               1485 ns         1465 ns       483753
read_generic              7859 ns         7753 ns        91012
write_struct               665 ns          659 ns      1067324
write_generic             1073 ns         1063 ns       660308
to_generic                3925 ns         3899 ns       177444
to_generic_via_json       8641 ns         8539 ns        81955
```

### Benchmark code

```c++
#include <benchmark/benchmark.h>

#include <string>

#include <rfl.hpp>
#include <rfl/json.hpp>

constexpr auto jsd = R"json({ "str": "hello", "i": 42 })json";

struct S { std::string str; int i; };

const S s_etalon{ .str = "hello", .i = 42 };
const rfl::Generic::Object g_etalon = [] () {
    rfl::Generic::Object ret;
    ret["str"] = "hello";
    ret["i"]   = 42;
    return ret;
} ();

using rfl::json::read;
using rfl::json::write;

void read_struct(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( read<S>(jsd).value() );
    }
} // <-- void read_struct(state)

void read_generic(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( read<rfl::Generic::Object>(jsd).value() );
    }
} // <-- void read_generic(state)

void write_struct(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( write(s_etalon) );
    }
} // <-- void write_struct(state)

void write_generic(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( write(g_etalon) );
    }
} // <-- void write_generic(state)

void to_generic(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( rfl::to_generic(s_etalon) );
    }
} // <-- void to_generic(state)

void to_generic_via_json(benchmark::State& state) {
    for (auto _ : state) {
        benchmark::DoNotOptimize( rfl::json::read<rfl::Generic::Object>(rfl::json::write(s_etalon)).value() );
    }
} // <-- void to_generic(state)

BENCHMARK(read_struct);
BENCHMARK(read_generic);
BENCHMARK(write_struct);
BENCHMARK(write_generic);
BENCHMARK(to_generic);
BENCHMARK(to_generic_via_json);

BENCHMARK_MAIN();
```