### PR TITLE
make read_one_alternative more general

### DIFF
--- a/include/rfl/parsing/Parser_variant.hpp
+++ b/include/rfl/parsing/Parser_variant.hpp
@@ -214,7 +214,7 @@ class Parser<R, W, std::variant<AlternativeTypes...>, ProcessorsType> {
           std::remove_cvref_t<internal::nth_element_t<_i, AlternativeTypes...>>;
       auto res = Parser<R, W, AltType, ProcessorsType>::read(_r, _var);
       if (res) {
-        _result->emplace(std::variant<AlternativeTypes...>{std::move(*res)});
+        _result->emplace(std::move(*res));
       } else {
         _errors->emplace_back(std::move(res.error()));
       }


### PR DESCRIPTION
MSVC 17.14 did not pick up the move assignment here and was complaining about a missing copy assignment operator in std::optional. Using emplace fixes the issue for me.

I did not run the tests locally, please let mo know if you need any further information!