### PR TITLE
Avoid defined but not used warning in `yyjson.c`

### DIFF
--- a/src/yyjson.c
+++ b/src/yyjson.c
@@ -4305,9 +4305,11 @@ static_inline u64 diy_fp_to_ieee_raw(diy_fp fp) {
 #define F64_POW10_EXP_MAX_EXACT 22
 
 /** Cached pow10 table. */
+#if YYJSON_DOUBLE_MATH_CORRECT
 static const f64 f64_pow10_table[] = {
     1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
     1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
+#endif
 
 /**
  Read a JSON number.


### PR DESCRIPTION
```
./src/yyjson.c:4308:18: warning: ‘f64_pow10_table’ defined but not used [-Wunused-const-variable=]
 4308 | static const f64 f64_pow10_table[] = {
      |                  ^~~~~~~~~~~~~~~
```