### PR TITLE
Fix target check for tomlplusplus in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,7 @@ if (REFLECTCPP_TOML OR REFLECTCPP_CHECK_HEADERS)
     list(APPEND REFLECT_CPP_SOURCES
         src/reflectcpp_toml.cpp
     )
-    if (NOT TARGET tomlplusplus)
+    if (NOT TARGET tomlplusplus::tomlplusplus)
       find_package(tomlplusplus)
     endif()
     target_link_libraries(reflectcpp PUBLIC tomlplusplus::tomlplusplus)


### PR DESCRIPTION
The check for the tomlplusplus target uses the wrong target name, so an externally provided tomlplusplus target is never detected and CMake always falls back to find_package.

It needs to use the same target name that is referenced in the adjacent target_link_libraries.