### PR TITLE
Hotfix -DREFLECTCPP_USE_STD_EXPECTED=ON

### DIFF
--- a/include/rfl/Result.hpp
+++ b/include/rfl/Result.hpp
@@ -454,7 +454,7 @@ class std::bad_expected_access<rfl::Error> : public bad_expected_access<void> {
 
   template <typename Self>
   [[nodiscard]]
-  auto error(this Self&& self) noexcept {
+  auto error(Self&& self) noexcept {
     return std::forward<Self>(self).err_;
   }
 


### PR DESCRIPTION
Minor change required to locally build with `-DREFLECTCPP_USE_STD_EXPECTED=ON`.

Addresses #570 .