### PR TITLE
build(cmake): add and install cmake version file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,12 +451,18 @@ if (REFLECTCPP_INSTALL)
     include(CMakePackageConfigHelpers)
 
     configure_package_config_file(reflectcpp-config.cmake.in
-      ${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-config.cmake
-      INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp
-      )
+        ${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp
+    )
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-version.cmake
+        COMPATIBILITY SameMinorVersion
+    )
 
     install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-config.cmake"
+        FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/reflectcpp-version.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/reflectcpp"
     )
 
@@ -467,13 +473,14 @@ if (REFLECTCPP_INSTALL)
         FILE_SET reflectcpp_headers
         TYPE HEADERS
         BASE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-        FILES ${RFL_HEADERS})
+        FILES ${RFL_HEADERS}
+    )
 
     install(
         TARGETS reflectcpp
         EXPORT reflectcpp-exports
         FILE_SET reflectcpp_headers DESTINATION ${INCLUDE_INSTALL_DIR}
-        )
+    )
 
     install(
         EXPORT reflectcpp-exports


### PR DESCRIPTION
This allowes consumers of the library to specify a version requirement and fail if it's not matched.