### PR TITLE
Add CMake option for toggling strict warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(REFLECTCPP_BUILD_SHARED "Build shared library" ${BUILD_SHARED_LIBS})
 option(REFLECTCPP_STRICT_WARNINGS "Enable strict compiler warnings" OFF)
-option(REFLECTCPP_INSTALL "Install reflect cpp" ON)
+option(REFLECTCPP_INSTALL "Install reflect cpp" OFF)
 
 option(REFLECTCPP_ALL_FORMATS "Enable all supported formats" OFF)
 option(REFLECTCPP_JSON "Enable JSON support" ON) # enabled by default


### PR DESCRIPTION
`-Wall` emits +1400 warnings on MSVC in debug mode. As much of this project is header-only, these carry over into dependent projects when used via CMake external-project/git submodules. This is disruptive to downstream projects using the library.

- I propose to add a new CMake option called `REFLECTCPP_STRICT_WARNINGS` to allow controlling these warning flags.
- For now, I have made it toggle on/off _all_ the warnings you are setting on your project (you might want to be more selective and allow some warnings in all cases, let me know what you want). 
- I've also defaulted the option to `OFF`, which I know might break some of your existing processes. Let me know if you want the default to be `ON`.