### PR TITLE
Fix capnproto add_value_to_map overwriting all entries at index 0

### DIFF
--- a/include/rfl/capnproto/Writer.hpp
+++ b/include/rfl/capnproto/Writer.hpp
@@ -186,10 +186,11 @@ class RFL_API Writer {
   template <class T>
   OutputVarType add_value_to_map(const std::string_view& _name, const T& _var,
                                  OutputMapType* _parent) const {
-    auto entries =
-        OutputArrayType{_parent->val_.get("entries").as<capnp::DynamicList>()};
+    auto entries = OutputArrayType{
+        .val_ = _parent->val_.get("entries").as<capnp::DynamicList>(),
+        .ix_ = _parent->ix_++};
     auto new_entry = add_object_to_array(2, &entries);
-    add_value_to_object("key", _name, &new_entry);
+    add_value_to_object("key", std::string(_name), &new_entry);
     return add_value_to_object("value", _var, &new_entry);
   }
 

--- a/tests/capnproto/test_map_value_types.cpp
+++ b/tests/capnproto/test_map_value_types.cpp
@@ -1,0 +1,25 @@
+#include <map>
+#include <rfl.hpp>
+#include <string>
+
+#include "write_and_read.hpp"
+
+namespace test_map_value_types {
+
+struct PersonWithStringMap {
+  rfl::Rename<"firstName", std::string> first_name;
+  std::map<std::string, std::string> nicknames;
+};
+
+TEST(capnproto, test_map_with_string_values) {
+  auto nicknames = std::map<std::string, std::string>();
+  nicknames["Bart"] = "El Barto";
+  nicknames["Lisa"] = "Lis";
+  nicknames["Maggie"] = "Mags";
+
+  const auto homer = PersonWithStringMap{.first_name = "Homer",
+                                         .nicknames = std::move(nicknames)};
+
+  write_and_read(homer);
+}
+}  // namespace test_map_value_types


### PR DESCRIPTION
## Summary

Fix a bug in capnproto's add_value_to_map, It doesn't use _parent->ix_++ to track the entry index. Instead, it creates a new OutputArrayType each time with ix_ defaulting to 0, so every entry overwrites index 0 in the capnproto list.

## Test plan

- [x] New test `capnproto.test_map_with_string_values` fails before the fix (only last entry survives round-trip)
- [x] New test passes after the fix
- [x] All 46 existing capnproto tests continue to pass
