### PR TITLE
Fix Cap'n Proto serialization of unsigned integer types

### DIFF
--- a/include/rfl/capnproto/Writer.hpp
+++ b/include/rfl/capnproto/Writer.hpp
@@ -171,6 +171,9 @@ class RFL_API Writer {
                          std::is_same<std::remove_cvref_t<T>, bool>()) {
       _parent->val_.set(_parent->ix_++, _var);
 
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      _parent->val_.set(_parent->ix_++, static_cast<std::uint64_t>(_var));
+
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
       _parent->val_.set(_parent->ix_++, static_cast<std::int64_t>(_var));
 
@@ -211,6 +214,10 @@ class RFL_API Writer {
                          std::is_same<std::remove_cvref_t<T>, bool>()) {
       _parent->val_.set(to_kj_string_ptr(_name), _var);
 
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      _parent->val_.set(to_kj_string_ptr(_name),
+                        static_cast<std::uint64_t>(_var));
+
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
       _parent->val_.set(to_kj_string_ptr(_name),
                         static_cast<std::int64_t>(_var));
@@ -241,6 +248,9 @@ class RFL_API Writer {
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>() ||
                          std::is_same<std::remove_cvref_t<T>, bool>()) {
       _parent->val_.set(field, _var);
+
+    } else if constexpr (std::is_unsigned<std::remove_cvref_t<T>>()) {
+      _parent->val_.set(field, static_cast<std::uint64_t>(_var));
 
     } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
       _parent->val_.set(field, static_cast<std::int64_t>(_var));

--- a/tests/capnproto/test_uint64.cpp
+++ b/tests/capnproto/test_uint64.cpp
@@ -1,0 +1,34 @@
+#include <rfl.hpp>
+#include <cstdint>
+#include <climits>
+#include <string>
+
+#include "write_and_read.hpp"
+
+namespace test_uint64 {
+
+struct UnsignedStruct {
+  uint64_t x = UINT64_MAX;
+  uint32_t y = UINT32_MAX;
+  uint16_t z = UINT16_MAX;
+  uint8_t w = UINT8_MAX;
+};
+
+TEST(capnproto, test_uint64) {
+  const auto s = UnsignedStruct{};
+  write_and_read(s);
+}
+
+TEST(capnproto, test_uint64_specific_values) {
+  const auto s = UnsignedStruct{
+      .x = 0, .y = 0, .z = 0, .w = 0};
+  write_and_read(s);
+}
+
+TEST(capnproto, test_uint64_max_values) {
+  const auto s = UnsignedStruct{
+      .x = UINT64_MAX, .y = UINT32_MAX, .z = UINT16_MAX, .w = UINT8_MAX};
+  write_and_read(s);
+}
+
+}  // namespace test_uint64


### PR DESCRIPTION
## Summary

serializing
```cpp
struct A {
  uint64_t x = UINT64_MAX;
}
```

in capnproto will throw:

```
[2025-10-22 23:43:22.981+08:00] [C] [238131] terminate called with an active exception, type: N2kj13ExceptionImplE, what: capnp/dynamic.c++:1710: failed: expected value >= 0 [-1 >= 0]; Value out-of-range for requested type.; value = -1
```

This PR fixes it.

## Test plan

- [x] New `test_uint64` tests fail without the fix (verified by reverting and rebuilding)
- [x] All 3 new tests pass with the fix applied
- [x] Full capnproto test suite (48 tests) passes with no regressions
