### PR TITLE
User controllable multiline string serialization for YAML

### DIFF
--- a/include/rfl/yaml/Reader.hpp
+++ b/include/rfl/yaml/Reader.hpp
@@ -87,7 +87,9 @@ struct Reader {
           // as a multiline string literal, but unfortunately yaml-cpp doesn't
           // seem to expose that information.
           auto last_non_new_line = result.find_last_not_of("\r\n");
-          result = result.substr(0, last_non_new_line + 1);
+          if (last_non_new_line != std::string::npos) {
+            result = result.substr(0, last_non_new_line + 1);
+          }
         }
         return result;
 

--- a/include/rfl/yaml/Reader.hpp
+++ b/include/rfl/yaml/Reader.hpp
@@ -49,7 +49,7 @@ struct Reader {
   static constexpr bool has_custom_constructor =
       (requires(InputVarType var) { T::from_yaml_obj(var); });
 
-  Reader(const std::string_view& _yaml_str) noexcept : yaml_str(_yaml_str) {}
+  Reader(const std::string_view& _yaml_str) noexcept : yaml_str_(_yaml_str) {}
 
   rfl::Result<InputVarType> get_field_from_array(
       const size_t _idx, const InputArrayType& _arr) const noexcept {
@@ -86,7 +86,7 @@ struct Reader {
           // new-lines here.
           //
           // This is only done for literal blocks which doesn't have tags or anchors
-          if (_var.node_.Tag() == "!" && yaml_str[_var.node_.Mark().pos] == '|') {
+          if (_var.node_.Tag() == "!" && yaml_str_[_var.node_.Mark().pos] == '|') {
             auto last_non_new_line = result.find_last_not_of("\r\n");
             if (last_non_new_line != std::string::npos) {
               result = result.substr(0, last_non_new_line + 1);
@@ -159,8 +159,8 @@ struct Reader {
     }
   }
 
-private:
-  std::string_view yaml_str;
+ private:
+  std::string_view yaml_str_;
 };
 
 }  // namespace yaml

--- a/include/rfl/yaml/Reader.hpp
+++ b/include/rfl/yaml/Reader.hpp
@@ -49,6 +49,8 @@ struct Reader {
   static constexpr bool has_custom_constructor =
       (requires(InputVarType var) { T::from_yaml_obj(var); });
 
+  Reader(const std::string_view& _yaml_str) noexcept : yaml_str(_yaml_str) {}
+
   rfl::Result<InputVarType> get_field_from_array(
       const size_t _idx, const InputArrayType& _arr) const noexcept {
     if (_idx >= _arr.node_.size()) {
@@ -83,12 +85,12 @@ struct Reader {
           // multiple re-serialization checks, for this reason we trim trailing
           // new-lines here.
           //
-          // It would be preferable to do this only if input string was stored
-          // as a multiline string literal, but unfortunately yaml-cpp doesn't
-          // seem to expose that information.
-          auto last_non_new_line = result.find_last_not_of("\r\n");
-          if (last_non_new_line != std::string::npos) {
-            result = result.substr(0, last_non_new_line + 1);
+          // This is only done for literal blocks which doesn't have tags or anchors
+          if (_var.node_.Tag() == "!" && yaml_str[_var.node_.Mark().pos] == '|') {
+            auto last_non_new_line = result.find_last_not_of("\r\n");
+            if (last_non_new_line != std::string::npos) {
+              result = result.substr(0, last_non_new_line + 1);
+            }
           }
         }
         return result;
@@ -156,6 +158,9 @@ struct Reader {
       return error(e.what());
     }
   }
+
+private:
+  std::string_view yaml_str;
 };
 
 }  // namespace yaml

--- a/include/rfl/yaml/Reader.hpp
+++ b/include/rfl/yaml/Reader.hpp
@@ -76,7 +76,20 @@ struct Reader {
       if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>() ||
                     std::is_same<std::remove_cvref_t<T>, bool>() ||
                     std::is_floating_point<std::remove_cvref_t<T>>()) {
-        return _var.node_.as<std::remove_cvref_t<T>>();
+        auto result = _var.node_.as<std::remove_cvref_t<T>>();
+        if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
+          // In case of multi-line YAML literal strings, yaml-cpp may parse an
+          // extra new line which is not there intentionally. This may break
+          // multiple re-serialization checks, for this reason we trim trailing
+          // new-lines here.
+          //
+          // It would be preferable to do this only if input string was stored
+          // as a multiline string literal, but unfortunately yaml-cpp doesn't
+          // seem to expose that information.
+          auto last_non_new_line = result.find_last_not_of("\r\n");
+          result = result.substr(0, last_non_new_line + 1);
+        }
+        return result;
 
       } else if constexpr (std::is_integral<std::remove_cvref_t<T>>()) {
         return static_cast<T>(_var.node_.as<std::remove_cvref_t<int64_t>>());

--- a/include/rfl/yaml/Writer.hpp
+++ b/include/rfl/yaml/Writer.hpp
@@ -15,6 +15,18 @@ namespace rfl::yaml {
 
 class RFL_API Writer {
  public:
+  enum Flags {
+    no_flags = 0,
+
+    /// A string value which has at least one new-line character will be written
+    /// as multiline YAML literal. It costs one call to std::basic_string::find
+    /// on all string values.
+    string_multiline_literal = 1,
+
+    /// All string values will be written as multiline YAML literal
+    string_all_literal = 2
+  };
+
   struct YAMLArray {};
 
   struct YAMLObject {};
@@ -25,7 +37,7 @@ class RFL_API Writer {
   using OutputObjectType = YAMLObject;
   using OutputVarType = YAMLVar;
 
-  Writer(const Ref<YAML::Emitter>& _out);
+  Writer(const Ref<YAML::Emitter>& _out, Flags _flags = no_flags);
 
   ~Writer();
 
@@ -87,7 +99,7 @@ class RFL_API Writer {
                              const T& _var) const {
     if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
       (*out_) << YAML::Key << std::string(_name) << YAML::Value;
-      if (_var.find('\n') != std::string::npos) {
+      if (flags & string_all_literal || (flags & string_multiline_literal && _var.find('\n') != std::string::npos)) {
         (*out_) << YAML::Literal;
       }
       (*out_) << _var;
@@ -112,7 +124,7 @@ class RFL_API Writer {
   template <class T>
   OutputVarType insert_value(const T& _var) const {
     if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
-      if (_var.find('\n') != std::string::npos) {
+      if (flags & string_all_literal || (flags & string_multiline_literal && _var.find('\n') != std::string::npos)) {
         (*out_) << YAML::Literal;
       }
       (*out_) << _var;
@@ -144,6 +156,7 @@ class RFL_API Writer {
 
  public:
   const Ref<YAML::Emitter> out_;
+  Flags flags;
 };
 
 }  // namespace rfl::yaml

--- a/include/rfl/yaml/Writer.hpp
+++ b/include/rfl/yaml/Writer.hpp
@@ -94,19 +94,27 @@ class RFL_API Writer {
 
   void end_object(OutputObjectType* _obj) const;
 
+ private:
+  template <class T>
+  void insert_literal_block_if_needed(const T& _var) const {
+    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
+      if (flags_ & string_all_literal || (flags_ & string_multiline_literal && _var.find('\n') != std::string::npos)) {
+        (*out_) << YAML::Literal;
+      }
+    }
+  }
+
+ public:
   template <class T>
   OutputVarType insert_value(const std::string_view& _name,
                              const T& _var) const {
-    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
+    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>() ||
+                  std::is_same<std::remove_cvref_t<T>, bool>() ||
+                  std::is_same<std::remove_cvref_t<T>,
+                               std::remove_cvref_t<decltype(YAML::Null)>>()) {
       (*out_) << YAML::Key << std::string(_name) << YAML::Value;
-      if (flags & string_all_literal || (flags & string_multiline_literal && _var.find('\n') != std::string::npos)) {
-        (*out_) << YAML::Literal;
-      }
+      insert_literal_block_if_needed(_var);
       (*out_) << _var;
-    } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>() ||
-                         std::is_same<std::remove_cvref_t<T>,
-                                      std::remove_cvref_t<decltype(YAML::Null)>>()) {
-      (*out_) << YAML::Key << std::string(_name) << YAML::Value << _var;
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       // std::to_string is necessary to ensure that floating point values are
       // always written as floats.
@@ -123,14 +131,11 @@ class RFL_API Writer {
 
   template <class T>
   OutputVarType insert_value(const T& _var) const {
-    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
-      if (flags & string_all_literal || (flags & string_multiline_literal && _var.find('\n') != std::string::npos)) {
-        (*out_) << YAML::Literal;
-      }
-      (*out_) << _var;
-    } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>() ||
-                         std::is_same<std::remove_cvref_t<T>,
-                                      std::remove_cvref_t<decltype(YAML::Null)>>()) {
+    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>() ||
+                  std::is_same<std::remove_cvref_t<T>, bool>() ||
+                  std::is_same<std::remove_cvref_t<T>,
+                               std::remove_cvref_t<decltype(YAML::Null)>>()) {
+      insert_literal_block_if_needed(_var);
       (*out_) << _var;
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       // std::to_string is necessary to ensure that floating point values are
@@ -156,7 +161,7 @@ class RFL_API Writer {
 
  public:
   const Ref<YAML::Emitter> out_;
-  Flags flags;
+  Flags flags_;
 };
 
 }  // namespace rfl::yaml

--- a/include/rfl/yaml/Writer.hpp
+++ b/include/rfl/yaml/Writer.hpp
@@ -85,10 +85,15 @@ class RFL_API Writer {
   template <class T>
   OutputVarType insert_value(const std::string_view& _name,
                              const T& _var) const {
-    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>() ||
-                  std::is_same<std::remove_cvref_t<T>, bool>() ||
-                  std::is_same<std::remove_cvref_t<T>,
-                               std::remove_cvref_t<decltype(YAML::Null)>>()) {
+    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
+      (*out_) << YAML::Key << std::string(_name) << YAML::Value;
+      if (_var.find('\n') != std::string::npos) {
+        (*out_) << YAML::Literal;
+      }
+      (*out_) << _var;
+    } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>() ||
+                         std::is_same<std::remove_cvref_t<T>,
+                                      std::remove_cvref_t<decltype(YAML::Null)>>()) {
       (*out_) << YAML::Key << std::string(_name) << YAML::Value << _var;
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       // std::to_string is necessary to ensure that floating point values are
@@ -106,10 +111,14 @@ class RFL_API Writer {
 
   template <class T>
   OutputVarType insert_value(const T& _var) const {
-    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>() ||
-                  std::is_same<std::remove_cvref_t<T>, bool>() ||
-                  std::is_same<std::remove_cvref_t<T>,
-                               std::remove_cvref_t<decltype(YAML::Null)>>()) {
+    if constexpr (std::is_same<std::remove_cvref_t<T>, std::string>()) {
+      if (_var.find('\n') != std::string::npos) {
+        (*out_) << YAML::Literal;
+      }
+      (*out_) << _var;
+    } else if constexpr (std::is_same<std::remove_cvref_t<T>, bool>() ||
+                         std::is_same<std::remove_cvref_t<T>,
+                                      std::remove_cvref_t<decltype(YAML::Null)>>()) {
       (*out_) << _var;
     } else if constexpr (std::is_floating_point<std::remove_cvref_t<T>>()) {
       // std::to_string is necessary to ensure that floating point values are

--- a/include/rfl/yaml/read.hpp
+++ b/include/rfl/yaml/read.hpp
@@ -18,8 +18,8 @@ using InputVarType = typename Reader::InputVarType;
 
 /// Parses an object from a YAML var.
 template <class T, class... Ps>
-auto read(const InputVarType& _var) {
-  const auto r = Reader();
+auto read(const InputVarType& _var, const std::string& _yaml_str) {
+  const auto r = Reader(_yaml_str);
   using ProcessorsType = Processors<Ps...>;
   static_assert(!ProcessorsType::no_field_names_,
                 "The NoFieldNames processor is not supported for BSON, XML, "
@@ -32,7 +32,7 @@ template <class T, class... Ps>
 Result<internal::wrap_in_rfl_array_t<T>> read(const std::string& _yaml_str) {
   try {
     const auto var = InputVarType(YAML::Load(_yaml_str));
-    return read<T, Ps...>(var);
+    return read<T, Ps...>(var, _yaml_str);
   } catch (std::exception& e) {
     return error(e.what());
   }

--- a/include/rfl/yaml/write.hpp
+++ b/include/rfl/yaml/write.hpp
@@ -17,11 +17,11 @@ namespace yaml {
 
 /// Writes a YAML into an ostream.
 template <class... Ps>
-std::ostream& write(const auto& _obj, std::ostream& _stream) {
+std::ostream& write(const auto& _obj, std::ostream& _stream, Writer::Flags _flags = Writer::Flags::no_flags) {
   using T = std::remove_cvref_t<decltype(_obj)>;
   using ParentType = parsing::Parent<Writer>;
   const auto out = Ref<YAML::Emitter>::make();
-  auto w = Writer(out);
+  auto w = Writer(out, _flags);
   using ProcessorsType = Processors<Ps...>;
   static_assert(!ProcessorsType::no_field_names_,
                 "The NoFieldNames processor is not supported for BSON, XML, "
@@ -33,11 +33,11 @@ std::ostream& write(const auto& _obj, std::ostream& _stream) {
 
 /// Returns a YAML string.
 template <class... Ps>
-std::string write(const auto& _obj) {
+std::string write(const auto& _obj, Writer::Flags _flags = Writer::Flags::no_flags) {
   using T = std::remove_cvref_t<decltype(_obj)>;
   using ParentType = parsing::Parent<Writer>;
   const auto out = Ref<YAML::Emitter>::make();
-  auto w = Writer(out);
+  auto w = Writer(out, _flags);
   using ProcessorsType = Processors<Ps...>;
   static_assert(!ProcessorsType::no_field_names_,
                 "The NoFieldNames processor is not supported for BSON, XML, "

--- a/src/rfl/yaml/Writer.cpp
+++ b/src/rfl/yaml/Writer.cpp
@@ -2,7 +2,7 @@
 
 namespace rfl::yaml {
 
-Writer::Writer(const Ref<YAML::Emitter>& _out) : out_(_out) {}
+Writer::Writer(const Ref<YAML::Emitter>& _out, Flags _flags) : out_(_out), flags(_flags) {}
 
 Writer::~Writer() = default;
 

--- a/src/rfl/yaml/Writer.cpp
+++ b/src/rfl/yaml/Writer.cpp
@@ -2,7 +2,7 @@
 
 namespace rfl::yaml {
 
-Writer::Writer(const Ref<YAML::Emitter>& _out, Flags _flags) : out_(_out), flags(_flags) {}
+Writer::Writer(const Ref<YAML::Emitter>& _out, Flags _flags) : out_(_out), flags_(_flags) {}
 
 Writer::~Writer() = default;
 

--- a/tests/yaml/test_multiline.cpp
+++ b/tests/yaml/test_multiline.cpp
@@ -11,7 +11,7 @@ struct MultilineTestStruct {
 namespace test_multiline {
 TEST(yaml, test_multiline) {
   const auto test = MultilineTestStruct{.normal_string = "The normal string",
-                               .multiline_string =
+                                        .multiline_string =
 R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -26,9 +26,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.)"
 
 TEST(yaml, test_multiline_read) {
   const auto test = MultilineTestStruct{.normal_string = "The normal string",
-                               .multiline_string =
-R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, etc...)"
+                                        .multiline_string = "Foobar\n\n"
   };
 
   const std::string random_yaml(
@@ -37,9 +35,7 @@ normal_string: |
   The normal string
 
 
-multiline_string: |
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, etc...
+multiline_string: "Foobar\n\n"
 
 )"
   );

--- a/tests/yaml/test_multiline.cpp
+++ b/tests/yaml/test_multiline.cpp
@@ -23,4 +23,30 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.)"
   write_and_read(test, rfl::yaml::Writer::string_multiline_literal);
   write_and_read(test, rfl::yaml::Writer::string_all_literal);
 }
+
+TEST(yaml, test_multiline_read) {
+  const auto test = MultilineTestStruct{.normal_string = "The normal string",
+                               .multiline_string =
+R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, etc...)"
+  };
+
+  const std::string random_yaml(
+R"(
+normal_string: |
+  The normal string
+
+
+multiline_string: |
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, etc...
+
+)"
+  );
+
+  auto read_result = rfl::yaml::read<MultilineTestStruct>(random_yaml);
+  EXPECT_TRUE(read_result.has_value());
+  EXPECT_EQ(read_result.value().normal_string, test.normal_string);
+  EXPECT_EQ(read_result.value().multiline_string, test.multiline_string);
+}
 }  // namespace test_multiline

--- a/tests/yaml/test_multiline.cpp
+++ b/tests/yaml/test_multiline.cpp
@@ -1,0 +1,26 @@
+#include <rfl.hpp>
+#include <string>
+
+#include "write_and_read.hpp"
+
+struct MultilineTestStruct {
+  std::string normal_string;
+  std::string multiline_string;
+};
+
+namespace test_multiline {
+TEST(yaml, test_multiline) {
+  const auto test = MultilineTestStruct{.normal_string = "The normal string",
+                               .multiline_string =
+R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id est laborum.)"
+  };
+
+  write_and_read(test, rfl::yaml::Writer::string_multiline_literal);
+  write_and_read(test, rfl::yaml::Writer::string_all_literal);
+}
+}  // namespace test_multiline

--- a/tests/yaml/write_and_read.hpp
+++ b/tests/yaml/write_and_read.hpp
@@ -6,14 +6,14 @@
 #include <rfl/yaml.hpp>
 
 template <class... Ps>
-void write_and_read(const auto& _struct) {
+void write_and_read(const auto& _struct, rfl::yaml::Writer::Flags _flags = rfl::yaml::Writer::Flags::no_flags) {
   using T = std::remove_cvref_t<decltype(_struct)>;
-  const auto serialized1 = rfl::yaml::write<Ps...>(_struct);
+  const auto serialized1 = rfl::yaml::write<Ps...>(_struct, _flags);
   const auto res = rfl::yaml::read<T, Ps...>(
       std::string_view(serialized1.c_str(), serialized1.size()));
   EXPECT_TRUE(res && true) << "Test failed on read. Error: "
                            << res.error().what();
-  const auto serialized2 = rfl::yaml::write<Ps...>(res.value());
+  const auto serialized2 = rfl::yaml::write<Ps...>(res.value(), _flags);
   EXPECT_EQ(serialized1, serialized2);
 }
 


### PR DESCRIPTION
This PR introduces

* an opt-in feature where string values can be serialized to `|` multiline literal blocks, if they contain new-line characters.
* Dealing with trailing new lines when reading from `|` multiline literal blocks.

## Writing multiline blocks 

By default this feature is not enabled to preserve previous behaviour, and because it costs a call to `std::basic_string::find` on all string fields.

In order to enable the feature the user needs to call `rfl::yaml::write` with respective flag:

```c++
  const auto test = MultilineTestStruct{.normal_string = "The normal string",
                                        .multiline_string =
R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo)"
  };
  auto yaml = rfl::yaml::write(test, rfl::yaml::Writer::string_multiline_literal);
```

Which produces

```yaml
normal_string: The normal string
multiline_string: |
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
```

in contrast to what it would produce without the flag:

```yaml
normal_string: The normal string
multiline_string: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\ntempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\nquis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
```

I've added another flag `string_all_literal` which forces all string values to be a multiline literal whether it actually has new-lines or not. This may be less commonly useful, but this will spare a call to `std::basic_string::find`, in case the user may have mostly long strings in their fields. When using that with the same example the output looks like this:

```yaml
normal_string: |
  The normal string
multiline_string: |
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
```

## Reading multiline blocks

While testing the latter case I've noticed that this style of multiline-string in YAML leaves a potentially unintentional new line at the end, which breaks re-serialization consistency checks. For this reason `rfl::yaml::Reader::to_basic_type` now trims the trailing new-lines from `|` literal block scalars. If given scalar is not a `|` literal block, then that's not affected.

For this trick `rfl::yaml::Reader` and in turn `rfl::yaml::read` now needs to know about the entire YAML input, so the reader can work with offset data provided by `YAML::Node::Mark()`. This may be a breaking change for the user, if they were directly working with `YAML::Node` inputs. Otherwise we wouldn't know if we could safely trim trailing new-lines, as yaml-cpp doesn't expose this information directly on the node.

To illustrate:

```yaml
foo: "String with important trailing new lines\n\n" # those two new-lines are preserved
bar: |
  Text with a bit of space afterwards
  (with a second line)

# above new lines are trimmed from the very-end
```

## Misc

It would be interesting to borrow the wisdom of the library author and/or the community in the following topics:

* Control these flags on field/struct basis instead of the entire serialized object.
  * I'm not yet knowledgeable enough for the internals of this library to see where that would be feasible to do.

I've run all YAML tests, introduced a new one for this feature, and just for safety I've run all JSON tests as well, however I didn't modify anything which would affect other serialization methods or reflections. All tests passed on my side.

Thanks for consideration and I'll be happy to address your feedbacks.