### PR TITLE
Fix MkDocs deployment on public mkdocs-material

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yaml
+++ b/.github/workflows/mkdocs-gh-pages.yaml
@@ -11,7 +11,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      GH_C17_DEV_TOKEN: ${{ secrets.GH_C17_DEV_TOKEN }}
       ENABLED_HTMLPROOFER: ${{ vars.ENABLED_HTMLPROOFER || 'False' }}
     steps:
       - name: Checkout reflect-cpp repo
@@ -37,7 +36,7 @@ jobs:
           git fetch origin gh-pages --depth=1
 
       - name: Deploy MkDocs documentation
-        run: hatch run insiders:mkdocs gh-deploy
+        run: hatch run default:mkdocs gh-deploy
 
       
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,6 @@ dynamic = ["version"]
 [tool.hatch.envs.default]
 dependencies = [
     "mkdocs~=1.6",
-    "mkdocs-material~=9.5",
-    "mkdocs-htmlproofer-plugin~=1.2",
-]
-
-[tool.hatch.envs.insiders]
-dependencies = [
-    "mkdocs~=1.6",
-    "mkdocs-material @ git+https://{env:GH_C17_DEV_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.39-insiders-4.53.14",
+    "mkdocs-material~=9.7",
     "mkdocs-htmlproofer-plugin~=1.2",
 ]


### PR DESCRIPTION
## Summary
Switch the documentation deployment away from the obsolete private Material Insiders repository and onto the public `mkdocs-material` package.

## Changes
- update the MkDocs deploy workflow to use `hatch run default:mkdocs gh-deploy`
- remove the `GH_C17_DEV_TOKEN` dependency from the deploy workflow
- update the Hatch docs dependency to `mkdocs-material~=9.7`
- remove the obsolete `insiders` Hatch environment

## Validation
- `hatch run default:mkdocs build`
- GitHub Actions `Deploy MkDocs documentation` run completed [successfully](https://github.com/getml/reflect-cpp/actions/runs/25436189343) for commit 5a95633.

More: https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/