### PR TITLE
no internal linkage in headers

### DIFF
--- a/include/rfl/internal/find_index.hpp
+++ b/include/rfl/internal/find_index.hpp
@@ -36,7 +36,7 @@ constexpr auto wrap_fields(std::integer_sequence<int, _is...>) {
 
 /// Finds the index of the field signified by _field_name
 template <StringLiteral _field_name, class Fields>
-constexpr static int find_index() {
+constexpr int find_index() {
   constexpr int ix = wrap_fields<_field_name, Fields>(
       std::make_integer_sequence<int, rfl::tuple_size_v<Fields>>());
   static_assert(rfl::tuple_element_t<ix, Fields>::name_ == _field_name,
@@ -46,7 +46,7 @@ constexpr static int find_index() {
 
 /// Finds the index of the field signified by _field_name or -1.
 template <StringLiteral _field_name, class Fields>
-constexpr static int find_index_or_minus_one() {
+constexpr int find_index_or_minus_one() {
   if constexpr (rfl::tuple_size_v<Fields> == 0) {
     return -1;
   } else {


### PR DESCRIPTION
If I want to export an struct that has a rfl::Field, this template references the changed function and therefore tries to reference a TU-local entity which is illegal.

<details><summary>Details</summary>
<p>

```
The stacktrace from gcc:
In file included from /root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Literal.hpp:14,
                 from /root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Field.hpp:8,
                 from /root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/AddStructName.hpp:6,
                 from /root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl.hpp:10,
                 from /root/.vs/src2/*****/lib/pdaLib/TestVariable.ixx:3:
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Tuple.hpp:229:7: error: 'using rfl::tuple_element_t = typename rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>::type' exposes TU-local entity 'struct rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>'
  229 | using tuple_element_t =
      |       ^~~~~~~~~~~~~~~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Tuple.hpp:216:8: note: 'struct rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>' refers to TU-local object 'ix'
  216 | struct tuple_element;
      |        ^~~~~~~~~~~~~
In file included from /root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Literal.hpp:16:
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/internal/find_index.hpp:40:17: note: 'ix' has no linkage and is declared within TU-local entity 'constexpr int rfl::internal::find_index()'
   40 |   constexpr int ix = wrap_fields<_field_name, Fields>(
      |                 ^~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/internal/find_index.hpp:39:22: note: 'constexpr int rfl::internal::find_index()' declared with internal linkage
   39 | constexpr static int find_index() {
      |                      ^~~~~~~~~~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Tuple.hpp:229:7: error: 'using rfl::tuple_element_t = typename rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>::type' exposes TU-local entity 'struct rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>'
  229 | using tuple_element_t =
      |       ^~~~~~~~~~~~~~~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/Tuple.hpp:216:8: note: 'struct rfl::tuple_element<ix, typename std::remove_cvref<_Tp2>::type>' refers to TU-local object 'ix'
  216 | struct tuple_element;
      |        ^~~~~~~~~~~~~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/internal/find_index.hpp:53:19: note: 'ix' has no linkage and is declared within TU-local entity 'constexpr int rfl::internal::find_index_or_minus_one()'
   53 |     constexpr int ix = wrap_fields<_field_name, Fields>(
      |                   ^~
/root/.vs/src2/out/build/x64-debug-linux/vcpkg_installed/x64-linux/include/rfl/internal/find_index.hpp:49:22: note: 'constexpr int rfl::internal::find_index_or_minus_one()' declared with internal linkage
   49 | constexpr static int find_index_or_minus_one() {
      |                      ^~~~~~~~~~~~~~~~~~~~~~~
``` 

</p>
</details> 
