### PR TITLE
Avoid clang 21/22 C++26-mode frontend crash in StringLiteral's variadic constructor

### DIFF
--- a/include/rfl/internal/StringLiteral.hpp
+++ b/include/rfl/internal/StringLiteral.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <concepts>
 #include <string>
 #include <string_view>
 
@@ -14,9 +15,11 @@ namespace internal {
 /// for the parameters names in the NamedTuples.
 template <size_t N>
 struct StringLiteral {
-  constexpr StringLiteral(const auto... _chars)
-    requires (std::is_same_v<decltype(_chars), const char> && ...)
-    : arr_{_chars..., '\0'} {}
+  /// Constrained via template type parameters rather than a requires-fold
+  /// over decltype of the function parameter pack: the latter crashes
+  /// clang 21/22 in C++26 mode (llvm/llvm-project#198052, #205000).
+  template <std::same_as<char>... Chars>
+  constexpr StringLiteral(const Chars... _chars) : arr_{_chars..., '\0'} {}
 
   constexpr StringLiteral(const std::array<char, N> _arr) : arr_(_arr) {}
 


### PR DESCRIPTION
## Problem

Any translation unit that includes reflect-cpp headers fails to compile at `-std=c++26` on clang 21.1+, 22.1.x, and current trunk: the compiler itself crashes (SIGSEGV in `CheckParameterPacksForExpansion`; assertion builds fail with `"declaration not instantiated in this scope"` in `LocalInstantiationScope::findInstantiationOf`) while parsing `using` aliases to `Literal<...>` / `NamedTuple<...>` types — e.g. `parsing/Parser_duration.hpp` and `parsing/Parser_result.hpp` are the first two headers hit. `-std=c++23` and earlier are unaffected.

Root cause is an open clang regression from the CWG2369 reapplication, not a reflect-cpp bug: llvm/llvm-project#198052, reported against reflect-cpp specifically in llvm/llvm-project#205000 (an 11-line minimized reproducer, reduced from `rfl::internal::StringLiteral`, is attached there). The trigger is `StringLiteral`'s variadic constructor constraining itself with a `requires`-fold over `decltype` of its own function parameter pack, alongside the competing `const char (&)[N]` constructor.

## Change

Constrain via template type parameters instead:

```cpp
template <std::same_as<char>... Chars>
constexpr StringLiteral(const Chars... _chars) : arr_{_chars..., '\0'} {}
```

Semantically equivalent — each argument must still be exactly `char` — and it sidesteps the clang bug on every version tested. Since the crash fires at parse time, this one constructor is the only change needed to make the whole library usable at C++26 on affected clangs; it can be reverted freely once fixed clang releases are common.

## Testing

Verified with clang 22.1.7 (libc++, `-fsyntax-only` and full builds): with this change, including `rfl/json.hpp`/`rfl/cbor.hpp` compiles cleanly at `-std=c++20/23/26`, and CBOR + JSON round-trips exercising `Literal`, `Field`, `TaggedUnion`, enums, optionals, and containers pass, including under ASan/UBSan. Please let your CI run the full suite to confirm.

## Disclosure

This fix was authored with an AI assistant (Claude Code) and reviewed/submitted by the account owner.