### PR TITLE
fix(tests): read cbor byte view via std::span, not basic_string_view<std::byte>

### DIFF
--- a/tests/cbor/test_read_byte_containers.cpp
+++ b/tests/cbor/test_read_byte_containers.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <rfl/cbor.hpp>
+#include <span>
 
 // Make sure things still compile when
 // rfl.hpp is included after rfl/cbor.hpp.
@@ -31,8 +33,13 @@ TEST(cbor, test_read_from_byte_view) {
   std::transform(rfl_buffer.begin(), rfl_buffer.end(), my_buffer.begin(),
                  [](char c) { return static_cast<std::byte>(c); });
 
-  std::basic_string_view<std::byte> byte_view(my_buffer.data(),
-                                              rfl_buffer.size());
+  // Note: std::span<const std::byte> rather than
+  // std::basic_string_view<std::byte>. libc++ (Xcode 26.5+) deprecates
+  // std::char_traits<std::byte> — the non-standard specialization that a
+  // basic_string_view<std::byte> instantiates — which is a hard error under
+  // -Werror. A span is the idiomatic non-owning byte view and exercises the
+  // same rfl::cbor::read overload (concepts::ContiguousByteContainer).
+  std::span<const std::byte> byte_view(my_buffer.data(), rfl_buffer.size());
 
   auto result = rfl::cbor::read<TestBox>(byte_view);
   EXPECT_TRUE(result);


### PR DESCRIPTION
## Problem

`macos-latest (tests)` is red on current CI (and will fail on `main` the next time that job runs — `main` is green only because its last macOS run predates the runner-image bump). The failure is in an unrelated test, not in whatever PR happens to trigger the run:

```
tests/cbor/test_read_byte_containers.cpp:34
  std::basic_string_view<std::byte> byte_view(...);
error: 'char_traits<std::byte>' is deprecated: char_traits<T> for T not equal to
char, wchar_t, char8_t, char16_t or char32_t is non-standard ... [-Werror,-Wdeprecated-declarations]
```

GitHub moved the `macos-latest` image to macOS 15 + Xcode 26.5, whose libc++ now marks `std::char_traits<T>` **deprecated** for any `T` outside `{char, wchar_t, char8_t, char16_t, char32_t}`. `std::basic_string_view<std::byte>` instantiates the now-deprecated `std::char_traits<std::byte>`, and the test suite builds with `-Werror` (`tests/CMakeLists.txt`), so the deprecation is a hard error.

It only shows up in one matrix cell because that cell is the sole intersection of "new libc++" and "compiles the tests": `macos-15-intel` still runs an older toolchain, and the `benchmarks` cells never compile the test files.

## Change

Read the CBOR bytes through `std::span<const std::byte>` instead of `std::basic_string_view<std::byte>`.

`std::span` is the idiomatic non-owning byte view, does **not** depend on `char_traits` at all, and satisfies the same `rfl::concepts::ContiguousByteContainer` that `rfl::cbor::read` requires (`std::byte` is byte-like; `ByteSpanLike`'s own doc-comment names span views as intended input) — so the test exercises the identical `read` overload. The sibling `std::uint8_t`-array test is unchanged.

The libc++ specialization is slated for **removal**, not just deprecation, so migrating off it is the durable fix rather than suppressing the warning with a diagnostic pragma.

## Testing

Verified with Apple clang 21 on macOS 26.5 (same libc++ that ships the deprecation), using the exact CI flags (`-std=gnu++20 -Wall -Werror -Wdeprecated-declarations`):

- The original `basic_string_view<std::byte>` reproduces the error.
- `std::span<const std::byte>` compiles clean and `static_assert`s green against the real `rfl::concepts::ContiguousByteContainer` / `ByteSpanLike` from `include/rfl/concepts.hpp`.

## Note

Independent of, and complementary to, #688 (a C++26 clang crash workaround touching only `StringLiteral.hpp`); that PR's red macOS cell is this same pre-existing toolchain regression, not anything in its diff.

---

*Disclosure: this investigation and patch were produced with the assistance of an AI coding agent (Claude Code / Claude Opus), reviewed by me before submitting.*