### PR TITLE
Add operator== for rfl::Generic and rfl::Object

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -63,3 +63,21 @@ There are three different ways of accessing fields:
 - `.get(...)` returns an `rfl::Result` wrapping the field, or an `rfl::Error` if the field doesn't exist.
 
 Note that it is most efficient, if you access fields in the order that they were placed.
+
+Two objects can be compared for equality using `operator==`. Because `rfl::Object`
+preserves insertion order and may contain duplicate keys, the comparison is
+*positional*: two objects are equal if and only if they contain the same
+key-value pairs in the same order.
+
+```cpp
+auto a = rfl::Object<std::string>();
+a["first_name"] = "Bart";
+a["last_name"] = "Simpson";
+
+auto b = rfl::Object<std::string>();
+b["last_name"] = "Simpson";
+b["first_name"] = "Bart";
+
+// false: a and b contain the same pairs, but in a different order.
+const bool equal = (a == b);
+```

--- a/include/rfl/Generic.hpp
+++ b/include/rfl/Generic.hpp
@@ -230,6 +230,29 @@ class RFL_API Generic {
   /// Returns the underlying variant.
   const VariantType& variant() const noexcept { return value_; };
 
+  /// Equality comparison. Two Generics are equal if they hold the same
+  /// alternative and the underlying values compare equal.
+  /// @param _lhs The left-hand side Generic
+  /// @param _rhs The right-hand side Generic
+  /// @return true if both Generics hold equal values
+  friend bool operator==(const Generic& _lhs, const Generic& _rhs) {
+    if (_lhs.value_.index() != _rhs.value_.index()) {
+      return false;
+    }
+    return std::visit(
+        [&](const auto& _val) -> bool {
+          using T = std::remove_cvref_t<decltype(_val)>;
+          if constexpr (std::is_same_v<T, std::nullopt_t>) {
+            // Both alternatives are null, which we consider equal.
+            return true;
+          } else {
+            // The indices are equal, so _rhs holds the same alternative.
+            return _val == std::get<T>(_rhs.value_);
+          }
+        },
+        _lhs.value_);
+  }
+
  private:
   /// Converts a ReflectionType to a VariantType.
   /// @param _r The reflection type (optional variant) to convert

--- a/include/rfl/Object.hpp
+++ b/include/rfl/Object.hpp
@@ -290,6 +290,18 @@ class Object {
     return data_[i].second;
   }
 
+  /// Equality comparison. Two objects are equal if they contain the same
+  /// key-value pairs in the same order. Note that the comparison is positional
+  /// rather than set-based, because rfl::Object preserves insertion order and
+  /// may contain duplicate keys.
+  /// @param _lhs The left-hand side object
+  /// @param _rhs The right-hand side object
+  /// @return true if both objects contain the same key-value pairs in the same
+  /// order
+  friend bool operator==(const Object<T>& _lhs, const Object<T>& _rhs) {
+    return _lhs.data_ == _rhs.data_;
+  }
+
  private:
   /// Finds the index of a key in the data vector.
   /// Uses a rotating search pattern starting from i_ for better cache locality.

--- a/tests/generic/test_equality.cpp
+++ b/tests/generic/test_equality.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include <rfl.hpp>
+
+namespace test_generic_equality {
+
+TEST(generic, equality_of_scalars) {
+  EXPECT_TRUE(rfl::Generic(int64_t{42}) == rfl::Generic(int64_t{42}));
+  EXPECT_FALSE(rfl::Generic(int64_t{42}) == rfl::Generic(int64_t{43}));
+  EXPECT_TRUE(rfl::Generic(std::string("abc")) ==
+              rfl::Generic(std::string("abc")));
+  EXPECT_FALSE(rfl::Generic(std::string("abc")) ==
+               rfl::Generic(std::string("abd")));
+  EXPECT_TRUE(rfl::Generic(true) == rfl::Generic(true));
+  EXPECT_FALSE(rfl::Generic(true) == rfl::Generic(false));
+  EXPECT_TRUE(rfl::Generic(3.14) == rfl::Generic(3.14));
+
+  // operator!= is synthesized from operator== in C++20.
+  EXPECT_TRUE(rfl::Generic(int64_t{42}) != rfl::Generic(int64_t{43}));
+  EXPECT_FALSE(rfl::Generic(int64_t{42}) != rfl::Generic(int64_t{42}));
+}
+
+TEST(generic, equality_of_different_alternatives) {
+  EXPECT_FALSE(rfl::Generic(int64_t{1}) == rfl::Generic(std::string("1")));
+  EXPECT_TRUE(rfl::Generic(int64_t{1}) != rfl::Generic(1.0));
+}
+
+TEST(generic, equality_of_null) {
+  const auto null1 = rfl::Generic();
+  const auto null2 = rfl::Generic();
+  EXPECT_TRUE(null1 == null2);
+  EXPECT_TRUE(null1 != rfl::Generic(int64_t{0}));
+}
+
+TEST(generic, equality_of_objects) {
+  rfl::Object<rfl::Generic> obj1;
+  obj1["a"] = rfl::Generic(int64_t{1});
+  obj1["b"] = rfl::Generic(std::string("x"));
+
+  rfl::Object<rfl::Generic> obj2;
+  obj2["a"] = rfl::Generic(int64_t{1});
+  obj2["b"] = rfl::Generic(std::string("x"));
+
+  EXPECT_TRUE(obj1 == obj2);
+}
+
+TEST(generic, equality_of_objects_is_order_dependent) {
+  // rfl::Object preserves insertion order and equality is positional, so
+  // objects with the same pairs in a different order are not equal.
+  rfl::Object<rfl::Generic> obj1;
+  obj1["a"] = rfl::Generic(int64_t{1});
+  obj1["b"] = rfl::Generic(std::string("x"));
+
+  rfl::Object<rfl::Generic> reordered;
+  reordered["b"] = rfl::Generic(std::string("x"));
+  reordered["a"] = rfl::Generic(int64_t{1});
+
+  EXPECT_FALSE(obj1 == reordered);
+}
+
+TEST(generic, equality_of_objects_with_duplicate_keys) {
+  // Duplicate keys are a supported state (e.g. produced by json::read).
+  // Positional comparison handles them correctly.
+  const std::string key = "k";
+
+  rfl::Object<rfl::Generic> obj1;
+  obj1.insert(key, rfl::Generic(int64_t{1}));
+  obj1.insert(key, rfl::Generic(int64_t{2}));
+
+  rfl::Object<rfl::Generic> same;
+  same.insert(key, rfl::Generic(int64_t{1}));
+  same.insert(key, rfl::Generic(int64_t{2}));
+  EXPECT_TRUE(obj1 == same);
+
+  rfl::Object<rfl::Generic> swapped;
+  swapped.insert(key, rfl::Generic(int64_t{2}));
+  swapped.insert(key, rfl::Generic(int64_t{1}));
+  EXPECT_FALSE(obj1 == swapped);
+}
+
+TEST(generic, inequality_of_objects) {
+  rfl::Object<rfl::Generic> obj1;
+  obj1["a"] = rfl::Generic(int64_t{1});
+  obj1["b"] = rfl::Generic(std::string("x"));
+
+  rfl::Object<rfl::Generic> different_value;
+  different_value["a"] = rfl::Generic(int64_t{1});
+  different_value["b"] = rfl::Generic(std::string("y"));
+  EXPECT_TRUE(obj1 != different_value);
+
+  rfl::Object<rfl::Generic> different_size;
+  different_size["a"] = rfl::Generic(int64_t{1});
+  EXPECT_TRUE(obj1 != different_size);
+
+  rfl::Object<rfl::Generic> different_key;
+  different_key["a"] = rfl::Generic(int64_t{1});
+  different_key["c"] = rfl::Generic(std::string("x"));
+  EXPECT_TRUE(obj1 != different_key);
+}
+
+TEST(generic, equality_of_nested_objects_and_arrays) {
+  const auto make = []() {
+    rfl::Object<rfl::Generic> inner;
+    inner["value"] = rfl::Generic(int64_t{7});
+    rfl::Generic::Array array{rfl::Generic(int64_t{1}),
+                              rfl::Generic(std::move(inner))};
+    rfl::Object<rfl::Generic> outer;
+    outer["array"] = rfl::Generic(std::move(array));
+    return rfl::Generic(std::move(outer));
+  };
+  EXPECT_TRUE(make() == make());
+}
+
+}  // namespace test_generic_equality


### PR DESCRIPTION
Resolves #693 

This adds `operator==` support to `Generic` and `Object`.

Note for `rfl::Object`, I made the comparison _positional_ (same key-value pairs in the same order). This is because `Object` allows for duplicate keys, so order-dependent comparison is more natural. A non-positional comparison would be `O(n^2)` in the worst case, which seems undesirable. Let me know if this is acceptable.

Code was generated with help of Claude. Above note is human-written.
