### PR TITLE
Preserve float width in MessagePack output

### DIFF
--- a/include/rfl/msgpack/Writer.hpp
+++ b/include/rfl/msgpack/Writer.hpp
@@ -124,10 +124,24 @@ class RFL_API Writer {
         }
       }
 
-    } else if constexpr (std::is_floating_point<Type>()) {
-      const auto err = msgpack_pack_double(pk_, static_cast<double>(_var));
+    } else if constexpr (std::is_same<Type, float>()) {
+      const auto err = msgpack_pack_float(pk_, _var);
+      if (err) {
+        throw std::runtime_error("Could not pack float.");
+      }
+
+    } else if constexpr (std::is_same<Type, double>()) {
+      const auto err = msgpack_pack_double(pk_, _var);
       if (err) {
         throw std::runtime_error("Could not pack double.");
+      }
+
+    } else if constexpr (std::is_floating_point<Type>()) {
+      // Preserve the existing narrowing behavior for floating-point types
+      // other than float and double.
+      const auto err = msgpack_pack_double(pk_, static_cast<double>(_var));
+      if (err) {
+        throw std::runtime_error("Could not pack floating-point value.");
       }
 
     } else if constexpr (std::is_unsigned<Type>()) {

--- a/tests/msgpack/test_floating_point_types.cpp
+++ b/tests/msgpack/test_floating_point_types.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include <msgpack.h>
+
+#include <rfl/msgpack.hpp>
+
+namespace test_floating_point_types {
+
+TEST(msgpack, writes_float_and_double_with_matching_wire_types) {
+  // Use equal numeric values so the C++ source type is the only difference.
+  const auto float_bytes = rfl::msgpack::write(1.0F);
+  const auto double_bytes = rfl::msgpack::write(1.0);
+
+  // Inspect the raw type because normal round-tripping accepts both widths.
+  msgpack_unpacked float_value;
+  msgpack_unpacked_init(&float_value);
+  ASSERT_TRUE(msgpack_unpack_next(&float_value, float_bytes.data(),
+                                  float_bytes.size(), nullptr));
+  EXPECT_EQ(float_value.data.type, MSGPACK_OBJECT_FLOAT32);
+  msgpack_unpacked_destroy(&float_value);
+
+  msgpack_unpacked double_value;
+  msgpack_unpacked_init(&double_value);
+  ASSERT_TRUE(msgpack_unpack_next(&double_value, double_bytes.data(),
+                                  double_bytes.size(), nullptr));
+  EXPECT_EQ(double_value.data.type, MSGPACK_OBJECT_FLOAT64);
+  msgpack_unpacked_destroy(&double_value);
+}
+
+}  // namespace test_floating_point_types


### PR DESCRIPTION
The MessagePack writer currently encodes both C++ `float` and `double` values as float64.

This change writes `float` values as MessagePack float32 while keeping `double` values as float64. A regression test checks both raw wire types.

Testing: all 47 MessagePack tests pass.

Fixes #708
