### PR TITLE
Reject externally tagged variants with more than one field

### DIFF
--- a/include/rfl/parsing/FieldVariantReader.hpp
+++ b/include/rfl/parsing/FieldVariantReader.hpp
@@ -43,6 +43,12 @@ class FieldVariantReader {
    */
   void read(const std::string_view& _disc_value,
             const InputVarType& _var) const noexcept {
+    if (*field_variant_) {
+      *field_variant_ = error(
+          "Could not parse rfl::Variant: Expected the object to have "
+          "exactly one field, but found more than one.");
+      return;
+    }
     try_matching_fields(
         _disc_value, _var,
         std::make_integer_sequence<int, sizeof...(FieldTypes)>());

--- a/tests/json/test_field_variant_multiple_fields.cpp
+++ b/tests/json/test_field_variant_multiple_fields.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <string>
+
+namespace test_field_variant_multiple_fields {
+
+struct Circle {
+  double radius;
+};
+
+struct Rectangle {
+  double height;
+  double width;
+};
+
+using Shapes =
+    rfl::Variant<rfl::Field<"circle", Circle>, rfl::Field<"rectangle", Rectangle>>;
+
+TEST(json, test_field_variant_multiple_fields) {
+  const std::string faulty_string =
+      R"({"circle":{"radius":2.0},"rectangle":{"height":10.0,"width":5.0}})";
+
+  const auto result = rfl::json::read<Shapes>(faulty_string);
+
+  EXPECT_TRUE(!result.has_value() && true);
+  EXPECT_EQ(result.error().what(),
+            "Could not parse rfl::Variant: Expected the object to have "
+            "exactly one field, but found more than one.");
+}
+
+TEST(json, test_field_variant_unknown_then_known_field) {
+  const std::string faulty_string =
+      R"({"triangle":{"base":3.0},"circle":{"radius":2.0}})";
+
+  const auto result = rfl::json::read<Shapes>(faulty_string);
+
+  EXPECT_TRUE(!result.has_value() && true);
+}
+
+}  // namespace test_field_variant_multiple_fields


### PR DESCRIPTION
Reading an `rfl::Variant<rfl::Field<...>, ...>` from an object with several keys silently keeps the last recognized tag. Worse, an unknown key followed by a valid tag overwrites the "could not match field" error, so `{"triangle": {...}, "circle": {...}}` parses successfully as a circle.

Serde, which this format models (per [variants_and_tagged_unions.md](https://rfl.getml.com/variants_and_tagged_unions/)), represents an externally tagged enum as a single-key map and rejects anything else, see [serde.rs/enum-representations.html](https://serde.rs/enum-representations.html#externally-tagged).

This change makes the reader return an error whenever a second field is encountered, mirroring the existing "expected the object to have exactly one field, but found none" error.

Added tests for both cases in `tests/json/test_field_variant_multiple_fields.cpp`.
