### PR TITLE
Output zero flag name if available

### DIFF
--- a/include/rfl/enums.hpp
+++ b/include/rfl/enums.hpp
@@ -72,7 +72,7 @@ std::string enum_to_string(const EnumType _enum) {
       val >>= 1;
     }
     if (flags.empty()) {
-      return "0";
+      return internal::enums::to_string(static_cast<EnumType>(0));
     }
     return internal::strings::join("|", flags);
   } else {

--- a/tests/json/test_enum8.cpp
+++ b/tests/json/test_enum8.cpp
@@ -32,7 +32,7 @@ TEST(json, test_enum8) {
   SomeClass t{
       .e = TestEnum::None, .f = TestEnum::Hello, .g = TestEnum::HelloWorld};
 
-  write_and_read(t, R"({"e":"0","f":"Hello","g":"Hello|World"})");
+  write_and_read(t, R"({"e":"None","f":"Hello","g":"Hello|World"})");
 }
 
 }  // namespace test_enum8


### PR DESCRIPTION
This makes it so enums output the name of the zero flag if it exists fixes #640 and #689