### PR TITLE
fix `Generic.cpp` build error due to missing includes

### DIFF
--- a/src/rfl/Generic.cpp
+++ b/src/rfl/Generic.cpp
@@ -26,6 +26,11 @@ SOFTWARE.
 
 #include "rfl/Generic.hpp"
 
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <variant>
+
 namespace rfl {
 
 Generic::Generic() : value_(std::nullopt) {}


### PR DESCRIPTION
I'm not sure why it works for others, but not for me. Maybe different compilation flags, since I'm wrapping the library in Bazel and not using the provided CMakeLists.